### PR TITLE
RXDB integration

### DIFF
--- a/.env
+++ b/.env
@@ -17,3 +17,8 @@ VITE_APP_LOGO=https://bv3c6-6aaaa-aaaap-abejq-cai.icp0.io/assets/hpl-wallet-f306
 VITE_APP_NAME=HPL
 # Market price in USD for ICRC1 cryptocurrencies
 VITE_APP_TOKEN_MARKET=https://nftpkg.com/api/icpcoins/list
+# Storage for user data
+VITE_DB_STORAGE=rxdb
+# Canister id of RXDB replica canister
+VITE_DB_CANISTER_ID=bd3sg-teaaa-aaaaa-qaaba-cai
+VITE_DB_CANISTER_HOST=http://127.0.0.1:8000

--- a/db-canister/db.mo
+++ b/db-canister/db.mo
@@ -1,0 +1,136 @@
+import Array "mo:base/Array";
+import Debug "mo:base/Debug";
+import Nat32 "mo:base/Nat32";
+import Nat64 "mo:base/Nat64";
+import Vector "mo:vector";
+
+import BTree "mo:stableheapbtreemap/BTree";
+import IDX "mo:rxmodb/index";
+import PK "mo:rxmodb/primarykey";
+import RXMDB "mo:rxmodb";
+
+module RxDbTable {
+
+  public func migrate<T1, PK1, T2, PK2>(src : DbInit<T1, PK1>, cast : (x : T1) -> T2, castPk : (x : PK1) -> PK2) : DbInit<T2, PK2> {
+    func castData(data : BTree.Data<PK1, Nat>) : BTree.Data<PK2, Nat> = {
+      var count = data.count;
+      kvs = Array.tabulateVar<?(PK2, Nat)>(
+        data.kvs.size(),
+        func(n) = switch (data.kvs[n]) { case (null) { null }; case (?k) { ?(castPk(k.0), k.1) } },
+      );
+    };
+    func castIndexNodeRecv(node : BTree.Node<PK1, Nat>) : BTree.Node<PK2, Nat> = switch (node) {
+      case (#leaf x) #leaf({ data = castData(x.data) });
+      case (#internal x) #internal({
+        children = Array.tabulateVar<?BTree.Node<PK2, Nat>>(
+          x.children.size(),
+          func(n) = switch (x.children[n]) {
+            case (null) { null };
+            case (?k) { ?castIndexNodeRecv(k) };
+          },
+        );
+        data = castData(x.data);
+      });
+    };
+    {
+      db = {
+        var reuse_queue = src.db.reuse_queue;
+        vec = Vector.map<?T1, ?T2>(
+          src.db.vec,
+          func(x) = switch (x) {
+            case (?item) ?cast(item);
+            case (null) null;
+          },
+        );
+      };
+      pk = {
+        order = src.pk.order;
+        var size = src.pk.size;
+        var root = castIndexNodeRecv(src.pk.root);
+      };
+      updatedAt = src.updatedAt;
+    };
+  };
+
+  public type DbInit<T, PK> = {
+    db : RXMDB.RXMDB<T>;
+    pk : PK.Init<PK>;
+    updatedAt : IDX.Init<Nat64>;
+  };
+
+  public type DbUse<T, PK> = {
+    db : RXMDB.Use<T>;
+    pk : PK.Use<PK, T>;
+    updatedAt : IDX.Use<Nat64, T>;
+  };
+
+  public func empty<T, PK>() : DbInit<T, PK> = {
+    db = RXMDB.init<T>();
+    pk = PK.init<PK>(?32);
+    updatedAt = IDX.init<Nat64>(?32);
+  };
+
+  public func use<T, PK>(
+    init : DbInit<T, PK>,
+    pkGet : (item : T) -> PK,
+    pkCompare : (pk1 : PK, pk2 : PK) -> { #less; #equal; #greater },
+    updatedAtGet : (item : T) -> Nat32,
+  ) : DbUse<T, PK> {
+    let obs = RXMDB.init_obs<T>();
+    // PK
+    let pk_config : PK.Config<PK, T> = {
+      db = init.db;
+      obs;
+      store = init.pk;
+      compare = pkCompare;
+      key = pkGet;
+      regenerate = #no;
+    };
+    PK.Subscribe<PK, T>(pk_config);
+
+    let updatedAt_config : IDX.Config<Nat64, T> = {
+      db = init.db;
+      obs;
+      store = init.updatedAt;
+      compare = Nat64.compare;
+      key = func(idx : Nat, d : T) = ?((Nat64.fromNat(Nat32.toNat(updatedAtGet(d))) << 32) | Nat64.fromNat(idx));
+      regenerate = #no;
+      keep = #all;
+    };
+    IDX.Subscribe(updatedAt_config);
+
+    return {
+      db = RXMDB.Use<T>(init.db, obs);
+      pk = PK.Use(pk_config);
+      updatedAt = IDX.Use(updatedAt_config);
+    };
+  };
+
+  public func pushUpdates<T, PK>(use : DbUse<T, PK>, docs : [T]) : [T] {
+    // var conflicts : Vector.Vector<TodoListItemDoc> = Vector.new();
+    for (doc in docs.vals()) {
+      use.db.insert(doc);
+      // let ?rec = callerDb.pk.get(doc.id) else Debug.trap("Not found");
+      // if (rec.revision != doc.revision + 1) {
+      //   Vector.add(conflicts, doc);
+      // };
+    };
+    // if (Vector.size(conflicts) > 0) return Vector.toArray(conflicts);
+    // for (doc in docs.vals()) {
+    //   callerDb.db.insert(doc);
+    // };
+    [];
+  };
+
+  public func getLatest<T, PK>(use : DbUse<T, PK>, updatedAt : Nat32, lastId : ?PK, limit : Nat) : [T] {
+    let start : Nat64 = switch (lastId) {
+      case (?id) {
+        let ?idx = use.pk.getIdx(id) else Debug.trap("ID not found");
+        (Nat64.fromNat(Nat32.toNat(updatedAt)) << 32) | Nat64.fromNat(idx);
+      };
+      case (null) Nat64.fromNat(Nat32.toNat(updatedAt)) << 32;
+    };
+    use.updatedAt.find(start, ^0, #bwd, limit);
+  };
+
+};

--- a/db-canister/main.mo
+++ b/db-canister/main.mo
@@ -1,0 +1,132 @@
+import AssocList "mo:base/AssocList";
+import Debug "mo:base/Debug";
+import Iter "mo:base/Iter";
+import List "mo:base/List";
+import Principal "mo:base/Principal";
+import Text "mo:base/Text";
+import Vector "mo:vector";
+
+import DB "db";
+
+actor class WalletDatabase() {
+
+  type StableStorage<Token, Contact> = AssocList.AssocList<Principal, (DB.DbInit<Token, Text>, DB.DbInit<Contact, Text>)>;
+  type TokenDocument_v0 = {
+    id : Text;
+    id_number : Nat64;
+    updatedAt : Nat32;
+    deleted : Bool;
+    address : Text;
+    symbol : Text;
+    name : Text;
+    decimal : Text;
+    subAccounts : [{
+      numb : Text;
+      name : Text;
+    }];
+    index : ?Text;
+    logo : ?Text;
+  };
+  type ContactDocument_v0 = {
+    name : Text;
+    updatedAt : Nat32;
+    deleted : Bool;
+    principal : Text;
+    accountIdentier : ?Text;
+    assets : [{
+      symbol : Text;
+      tokenSymbol : Text;
+      logo : ?Text;
+      subaccounts : [{
+        name : Text;
+        subaccount_index : Text;
+      }];
+    }];
+  };
+
+  stable var storage_v0 : StableStorage<TokenDocument_v0, ContactDocument_v0> = null;
+  // example how to migrate schema to next version. Uncomment, implement cast functions, replace types below and use new stable var storage_vX everywhere instead of old storage_v0.
+  // after initial upgrade v0 stable variable can be deleted
+  // Note that it was written before refactoring primary keys, so should be updated accordingly
+  // stable var storage_v1 : StableStorage<TokenDocument_v1, ContactDocument_v1> = (
+  //   func migrateV1() : StableStorage<TokenDocument_v1, ContactDocument_v1> {
+  //     let castToken = func(item : TokenDocument_v0) : TokenDocument_v1 = item;
+  //     let castContact = func(item : ContactDocument_v0) : ContactDocument_v1 = item;
+  //     let res = List.map<(Principal, (DB.DbInit<TokenDocument_v1>, DB.DbInit<ContactDocument_v1>)), (Principal, (DB.DbInit<TokenDocument_v1>, DB.DbInit<ContactDocument_v1>))>(
+  //       storage_v0,
+  //       func((p, (x, y))) = (p, (DB.migrate(x, castToken), DB.migrate(y, castContact))),
+  //     );
+  //     storage_v0 := null;
+  //     res;
+  //   }
+  // )();
+
+  // update these when migrating database
+  type TokenDocument = TokenDocument_v0;
+  type ContactDocument = ContactDocument_v0;
+
+  var databasesCache : AssocList.AssocList<Principal, (DB.DbUse<TokenDocument, Text>, DB.DbUse<ContactDocument, Text>)> = null;
+
+  private func getDatabase(owner : Principal, notFoundStrategy : { #create; #returnNull }) : ?(DB.DbUse<TokenDocument, Text>, DB.DbUse<ContactDocument, Text>) {
+    switch (AssocList.find(databasesCache, owner, Principal.equal)) {
+      case (?db) ?db;
+      case (null) {
+        let (tInit, cInit) = switch (AssocList.find(storage_v0, owner, Principal.equal)) {
+          case (?store) store;
+          case (null) {
+            switch (notFoundStrategy) {
+              case (#returnNull) return null;
+              case (#create) {
+                let store = (DB.empty<TokenDocument, Text>(), DB.empty<ContactDocument, Text>());
+                let (upd, _) = AssocList.replace(storage_v0, owner, Principal.equal, ?store);
+                storage_v0 := upd;
+                store;
+              };
+            };
+          };
+        };
+        let db = (
+          DB.use<TokenDocument, Text>(tInit, func(x) = x.id, Text.compare, func(x) = x.updatedAt),
+          DB.use<ContactDocument, Text>(cInit, func(x) = x.name, Text.compare, func(x) = x.updatedAt),
+        );
+        let (upd, _) = AssocList.replace(databasesCache, owner, Principal.equal, ?db);
+        databasesCache := upd;
+        ?db;
+      };
+    };
+  };
+
+  public shared ({ caller }) func pushTokens(docs : [TokenDocument]) : async [TokenDocument] {
+    let ?(tdb, _) = getDatabase(caller, #create) else Debug.trap("Can never happen");
+    DB.pushUpdates(tdb, docs);
+  };
+
+  public shared ({ caller }) func pushContacts(docs : [ContactDocument]) : async [ContactDocument] {
+    let ?(_, cdb) = getDatabase(caller, #create) else Debug.trap("Can never happen");
+    DB.pushUpdates(cdb, docs);
+  };
+
+  public shared query ({ caller }) func pullTokens(updatedAt : Nat32, lastId : ?Text, limit : Nat) : async [TokenDocument] {
+    switch (getDatabase(caller, #returnNull)) {
+      case (?(tdb, _)) DB.getLatest(tdb, updatedAt, lastId, limit);
+      case (null)[];
+    };
+  };
+
+  public shared query ({ caller }) func pullContacts(updatedAt : Nat32, lastId : ?Text, limit : Nat) : async [ContactDocument] {
+    switch (getDatabase(caller, #returnNull)) {
+      case (?(_, cdb)) DB.getLatest(cdb, updatedAt, lastId, limit);
+      case (null)[];
+    };
+  };
+
+  public shared query ({ caller }) func dump() : async [(Principal, ([?TokenDocument], [?ContactDocument]))] {
+    Iter.toArray<(Principal, ([?TokenDocument], [?ContactDocument]))>(
+      Iter.map<(Principal, (DB.DbInit<TokenDocument, Text>, DB.DbInit<ContactDocument, Text>)), (Principal, ([?TokenDocument], [?ContactDocument]))>(
+        List.toIter(storage_v0),
+        func((p, (t, c))) = (p, (Vector.toArray<?TokenDocument>(t.db.vec), Vector.toArray<?ContactDocument>(c.db.vec))),
+      )
+    );
+  };
+
+};

--- a/dfx.json
+++ b/dfx.json
@@ -6,11 +6,20 @@
       },
       "source": ["dist/"],
       "type": "assets"
+    },
+    "db": {
+      "main": "db-canister/main.mo",
+      "type": "motoko",
+      "optimize": "cycles",
+      "declarations": {
+        "output": "frontend/database/candid"
+      }
     }
   },
   "defaults": {
     "build": {
-      "packtool": ""
+      "args": "",
+      "packtool": "mops sources"
     }
   },
   "networks": {

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -7,12 +7,13 @@ import "./App.scss";
 import { AuthClient } from "@dfinity/auth-client";
 import { handleLoginApp } from "@redux/CheckAuth";
 import { setAuth } from "@redux/auth/AuthReducer";
+import { db } from "@/database/db";
 
 const App: React.FC = () => {
   const { i18n } = useTranslation();
 
   useEffect(() => {
-    const language = localStorage.getItem("language");
+    const language = db().getLanguage();
     if (language !== undefined && language !== null && language !== "" && language !== "null") {
       i18n.changeLanguage(language);
     }

--- a/frontend/database/candid/db.did
+++ b/frontend/database/candid/db.did
@@ -1,0 +1,53 @@
+type WalletDatabase = 
+ service {
+   dump: () ->
+    (vec
+      record {
+        principal;
+        record {
+          vec opt TokenDocument;
+          vec opt ContactDocument;
+        };
+      }) query;
+   pullContacts: (nat32, opt text, nat) -> (vec ContactDocument) query;
+   pullTokens: (nat32, opt text, nat) -> (vec TokenDocument) query;
+   pushContacts: (vec ContactDocument) -> (vec ContactDocument);
+   pushTokens: (vec TokenDocument) -> (vec TokenDocument);
+ };
+type TokenDocument = 
+ record {
+   address: text;
+   decimal: text;
+   deleted: bool;
+   id: text;
+   id_number: nat64;
+   index: opt text;
+   logo: opt text;
+   name: text;
+   subAccounts: vec record {
+                      name: text;
+                      numb: text;
+                    };
+   symbol: text;
+   updatedAt: nat32;
+ };
+type ContactDocument = 
+ record {
+   accountIdentier: opt text;
+   assets:
+    vec
+     record {
+       logo: opt text;
+       subaccounts: vec record {
+                          name: text;
+                          subaccount_index: text;
+                        };
+       symbol: text;
+       tokenSymbol: text;
+     };
+   deleted: bool;
+   name: text;
+   "principal": text;
+   updatedAt: nat32;
+ };
+service : () -> WalletDatabase

--- a/frontend/database/candid/db.did.d.ts
+++ b/frontend/database/candid/db.did.d.ts
@@ -1,0 +1,53 @@
+import type { Principal } from '@dfinity/principal';
+import type { ActorMethod } from '@dfinity/agent';
+
+export interface ContactDocument {
+  'principal' : string,
+  'deleted' : boolean,
+  'name' : string,
+  'assets' : Array<
+    {
+      'subaccounts' : Array<{ 'name' : string, 'subaccount_index' : string }>,
+      'logo' : [] | [string],
+      'tokenSymbol' : string,
+      'symbol' : string,
+    }
+  >,
+  'updatedAt' : number,
+  'accountIdentier' : [] | [string],
+}
+export interface TokenDocument {
+  'id' : string,
+  'deleted' : boolean,
+  'logo' : [] | [string],
+  'name' : string,
+  'updatedAt' : number,
+  'address' : string,
+  'index' : [] | [string],
+  'decimal' : string,
+  'id_number' : bigint,
+  'subAccounts' : Array<{ 'name' : string, 'numb' : string }>,
+  'symbol' : string,
+}
+export interface WalletDatabase {
+  'dump' : ActorMethod<
+    [],
+    Array<
+      [Principal, [Array<[] | [TokenDocument]>, Array<[] | [ContactDocument]>]]
+    >
+  >,
+  'pullContacts' : ActorMethod<
+    [number, [] | [string], bigint],
+    Array<ContactDocument>
+  >,
+  'pullTokens' : ActorMethod<
+    [number, [] | [string], bigint],
+    Array<TokenDocument>
+  >,
+  'pushContacts' : ActorMethod<
+    [Array<ContactDocument>],
+    Array<ContactDocument>
+  >,
+  'pushTokens' : ActorMethod<[Array<TokenDocument>], Array<TokenDocument>>,
+}
+export interface _SERVICE extends WalletDatabase {}

--- a/frontend/database/candid/db.did.js
+++ b/frontend/database/candid/db.did.js
@@ -1,0 +1,73 @@
+export const idlFactory = ({ IDL }) => {
+  const TokenDocument = IDL.Record({
+    'id' : IDL.Text,
+    'deleted' : IDL.Bool,
+    'logo' : IDL.Opt(IDL.Text),
+    'name' : IDL.Text,
+    'updatedAt' : IDL.Nat32,
+    'address' : IDL.Text,
+    'index' : IDL.Opt(IDL.Text),
+    'decimal' : IDL.Text,
+    'id_number' : IDL.Nat64,
+    'subAccounts' : IDL.Vec(
+      IDL.Record({ 'name' : IDL.Text, 'numb' : IDL.Text })
+    ),
+    'symbol' : IDL.Text,
+  });
+  const ContactDocument = IDL.Record({
+    'principal' : IDL.Text,
+    'deleted' : IDL.Bool,
+    'name' : IDL.Text,
+    'assets' : IDL.Vec(
+      IDL.Record({
+        'subaccounts' : IDL.Vec(
+          IDL.Record({ 'name' : IDL.Text, 'subaccount_index' : IDL.Text })
+        ),
+        'logo' : IDL.Opt(IDL.Text),
+        'tokenSymbol' : IDL.Text,
+        'symbol' : IDL.Text,
+      })
+    ),
+    'updatedAt' : IDL.Nat32,
+    'accountIdentier' : IDL.Opt(IDL.Text),
+  });
+  const WalletDatabase = IDL.Service({
+    'dump' : IDL.Func(
+        [],
+        [
+          IDL.Vec(
+            IDL.Tuple(
+              IDL.Principal,
+              IDL.Tuple(
+                IDL.Vec(IDL.Opt(TokenDocument)),
+                IDL.Vec(IDL.Opt(ContactDocument)),
+              ),
+            )
+          ),
+        ],
+        ['query'],
+      ),
+    'pullContacts' : IDL.Func(
+        [IDL.Nat32, IDL.Opt(IDL.Text), IDL.Nat],
+        [IDL.Vec(ContactDocument)],
+        ['query'],
+      ),
+    'pullTokens' : IDL.Func(
+        [IDL.Nat32, IDL.Opt(IDL.Text), IDL.Nat],
+        [IDL.Vec(TokenDocument)],
+        ['query'],
+      ),
+    'pushContacts' : IDL.Func(
+        [IDL.Vec(ContactDocument)],
+        [IDL.Vec(ContactDocument)],
+        [],
+      ),
+    'pushTokens' : IDL.Func(
+        [IDL.Vec(TokenDocument)],
+        [IDL.Vec(TokenDocument)],
+        [],
+      ),
+  });
+  return WalletDatabase;
+};
+export const init = ({ IDL }) => { return []; };

--- a/frontend/database/candid/index.d.ts
+++ b/frontend/database/candid/index.d.ts
@@ -1,0 +1,50 @@
+import type {
+  ActorSubclass,
+  HttpAgentOptions,
+  ActorConfig,
+  Agent,
+} from "@dfinity/agent";
+import type { Principal } from "@dfinity/principal";
+import type { IDL } from "@dfinity/candid";
+
+import { _SERVICE } from './db.did';
+
+export declare const idlFactory: IDL.InterfaceFactory;
+export declare const canisterId: string;
+
+export declare interface CreateActorOptions {
+  /**
+   * @see {@link Agent}
+   */
+  agent?: Agent;
+  /**
+   * @see {@link HttpAgentOptions}
+   */
+  agentOptions?: HttpAgentOptions;
+  /**
+   * @see {@link ActorConfig}
+   */
+  actorOptions?: ActorConfig;
+}
+
+/**
+ * Intializes an {@link ActorSubclass}, configured with the provided SERVICE interface of a canister.
+ * @constructs {@link ActorSubClass}
+ * @param {string | Principal} canisterId - ID of the canister the {@link Actor} will talk to
+ * @param {CreateActorOptions} options - see {@link CreateActorOptions}
+ * @param {CreateActorOptions["agent"]} options.agent - a pre-configured agent you'd like to use. Supercedes agentOptions
+ * @param {CreateActorOptions["agentOptions"]} options.agentOptions - options to set up a new agent
+ * @see {@link HttpAgentOptions}
+ * @param {CreateActorOptions["actorOptions"]} options.actorOptions - options for the Actor
+ * @see {@link ActorConfig}
+ */
+export declare const createActor: (
+  canisterId: string | Principal,
+  options?: CreateActorOptions
+) => ActorSubclass<_SERVICE>;
+
+/**
+ * Intialized Actor using default settings, ready to talk to a canister using its candid interface
+ * @constructs {@link ActorSubClass}
+ */
+export declare const db: ActorSubclass<_SERVICE>;

--- a/frontend/database/candid/index.js
+++ b/frontend/database/candid/index.js
@@ -1,0 +1,43 @@
+import { Actor, HttpAgent } from "@dfinity/agent";
+
+// Imports and re-exports candid interface
+import { idlFactory } from "./db.did.js";
+export { idlFactory } from "./db.did.js";
+
+/* CANISTER_ID is replaced by webpack based on node environment
+ * Note: canister environment variable will be standardized as
+ * process.env.CANISTER_ID_<CANISTER_NAME_UPPERCASE>
+ * beginning in dfx 0.15.0
+ */
+export const canisterId =
+  process.env.CANISTER_ID_DB ||
+  process.env.DB_CANISTER_ID;
+
+export const createActor = (canisterId, options = {}) => {
+  const agent = options.agent || new HttpAgent({ ...options.agentOptions });
+
+  if (options.agent && options.agentOptions) {
+    console.warn(
+      "Detected both agent and agentOptions passed to createActor. Ignoring agentOptions and proceeding with the provided agent."
+    );
+  }
+
+  // Fetch root key for certificate validation during development
+  if (process.env.DFX_NETWORK !== "ic") {
+    agent.fetchRootKey().catch((err) => {
+      console.warn(
+        "Unable to fetch root key. Check to ensure that your local replica is running"
+      );
+      console.error(err);
+    });
+  }
+
+  // Creates an actor with using the candid interface and the HttpAgent
+  return Actor.createActor(idlFactory, {
+    agent,
+    canisterId,
+    ...options.actorOptions,
+  });
+};
+
+export const db = createActor(canisterId);

--- a/frontend/database/db.ts
+++ b/frontend/database/db.ts
@@ -1,0 +1,9 @@
+import { RxdbDatabase } from "@/database/rxdb.database";
+import { IWalletDatabase } from "@/database/i-wallet-database";
+import { LocalStorageDatabase } from "@/database/local-storage.database";
+
+
+const _db: IWalletDatabase = import.meta.env.VITE_DB_STORAGE === "rxdb" ? RxdbDatabase.instance : LocalStorageDatabase.instance;
+export const db: () => IWalletDatabase = () => {
+  return _db;
+};

--- a/frontend/database/i-wallet-database.ts
+++ b/frontend/database/i-wallet-database.ts
@@ -48,8 +48,6 @@ export abstract class IWalletDatabase {
 
   abstract updateToken(id_number: number, newDoc: Token): Promise<void>;
 
-  abstract setTokens(allTokens: Token[]): Promise<void>;
-
   abstract getContact(principal: string): Promise<Contact | null>;
 
   abstract getContacts(): Promise<Contact[]>;

--- a/frontend/database/i-wallet-database.ts
+++ b/frontend/database/i-wallet-database.ts
@@ -1,6 +1,7 @@
 import { AuthNetwork, Token } from "@redux/models/TokenModels";
 import { Contact } from "@redux/models/ContactsModels";
 import { Identity } from "@dfinity/agent";
+import { Observable } from "rxjs";
 
 export abstract class IWalletDatabase {
   abstract init(): Promise<void>;
@@ -9,6 +10,7 @@ export abstract class IWalletDatabase {
   getLanguage(): string | null {
     return localStorage.getItem("language");
   }
+
   setLanguage(value: string): void {
     localStorage.setItem("language", value);
   }
@@ -16,6 +18,7 @@ export abstract class IWalletDatabase {
   getTheme(): "dark" | "light" | null {
     return localStorage.theme;
   }
+
   setTheme(value: "dark" | "light"): void {
     localStorage.theme = value;
   }
@@ -23,6 +26,7 @@ export abstract class IWalletDatabase {
   getNetworkType(): AuthNetwork | null {
     return JSON.parse(localStorage.getItem("network_type") || "null");
   }
+
   setNetworkType(value: AuthNetwork): void {
     localStorage.setItem("network_type", JSON.stringify({
       type: value.type,
@@ -34,11 +38,27 @@ export abstract class IWalletDatabase {
   // user data
   abstract setIdentity(identity: Identity | null): void;
 
+  abstract getToken(id_number: number): Promise<Token | null>;
+
   abstract getTokens(): Promise<Token[]>;
+
+  abstract subscribeToAllTokens(): Observable<Token[]>;
+
+  abstract addToken(token: Token): Promise<void>;
+
+  abstract updateToken(id_number: number, newDoc: Token): Promise<void>;
 
   abstract setTokens(allTokens: Token[]): Promise<void>;
 
+  abstract getContact(principal: string): Promise<Contact | null>;
+
   abstract getContacts(): Promise<Contact[]>;
 
-  abstract setContacts(allContacts: Contact[]): Promise<void>;
+  abstract subscribeToAllContacts(): Observable<Contact[]>;
+
+  abstract addContact(contact: Contact): Promise<void>;
+
+  abstract updateContact(principal: string, newDoc: Contact): Promise<void>;
+
+  abstract deleteContact(principal: string): Promise<void>;
 }

--- a/frontend/database/i-wallet-database.ts
+++ b/frontend/database/i-wallet-database.ts
@@ -1,0 +1,44 @@
+import { AuthNetwork, Token } from "@redux/models/TokenModels";
+import { Contact } from "@redux/models/ContactsModels";
+import { Identity } from "@dfinity/agent";
+
+export abstract class IWalletDatabase {
+  abstract init(): Promise<void>;
+
+  // various client settings
+  getLanguage(): string | null {
+    return localStorage.getItem("language");
+  }
+  setLanguage(value: string): void {
+    localStorage.setItem("language", value);
+  }
+
+  getTheme(): "dark" | "light" | null {
+    return localStorage.theme;
+  }
+  setTheme(value: "dark" | "light"): void {
+    localStorage.theme = value;
+  }
+
+  getNetworkType(): AuthNetwork | null {
+    return JSON.parse(localStorage.getItem("network_type") || "null");
+  }
+  setNetworkType(value: AuthNetwork): void {
+    localStorage.setItem("network_type", JSON.stringify({
+      type: value.type,
+      network: value.network,
+      name: value.name,
+    }));
+  }
+
+  // user data
+  abstract setIdentity(identity: Identity | null): void;
+
+  abstract getTokens(): Promise<Token[]>;
+
+  abstract setTokens(allTokens: Token[]): Promise<void>;
+
+  abstract getContacts(): Promise<Contact[]>;
+
+  abstract setContacts(allContacts: Contact[]): Promise<void>;
+}

--- a/frontend/database/local-storage.database.ts
+++ b/frontend/database/local-storage.database.ts
@@ -46,18 +46,18 @@ export class LocalStorageDatabase extends IWalletDatabase {
 
   async addToken(token: Token): Promise<void> {
     const tokens = this._getTokens();
-    await this.setTokens([...tokens, token]);
+    this.setTokens([...tokens, token]);
   }
 
   async updateToken(id_number: number, newDoc: Token): Promise<void> {
-    await this.setTokens(this._getTokens().map((tkn) => {
+    this.setTokens(this._getTokens().map((tkn) => {
       if (tkn.id_number === id_number) {
         return newDoc;
       } else return tkn;
     }));
   }
 
-  async setTokens(allTokens: Token[]): Promise<void> {
+  private setTokens(allTokens: Token[]) {
     const tokens = allTokens.sort((a, b) => {
       return a.id_number - b.id_number;
     });

--- a/frontend/database/local-storage.database.ts
+++ b/frontend/database/local-storage.database.ts
@@ -2,6 +2,7 @@ import { IWalletDatabase } from "@/database/i-wallet-database";
 import { Token } from "@redux/models/TokenModels";
 import { Contact } from "@redux/models/ContactsModels";
 import { Identity } from "@dfinity/agent";
+import { BehaviorSubject, Observable } from "rxjs";
 
 export class LocalStorageDatabase extends IWalletDatabase {
   private static _instance: LocalStorageDatabase | undefined;
@@ -20,34 +21,97 @@ export class LocalStorageDatabase extends IWalletDatabase {
 
   setIdentity(identity: Identity | null): void {
     this.authPrincipal = identity?.getPrincipal().toText() || "";
+    this.tokens$.next(this._getTokens());
+    this.contacts$.next(this._getContacts());
   }
 
-  async getTokens(): Promise<Token[]> {
+  private readonly tokens$: BehaviorSubject<Token[]> = new BehaviorSubject<Token[]>(this._getTokens());
+
+  private _getTokens(): Token[] {
     const userData = JSON.parse(localStorage.getItem(this.authPrincipal) || "null");
     return userData?.tokens || [];
   }
 
-  async setTokens(allTokens: Token[]): Promise<void> {
-    localStorage.setItem(this.authPrincipal, JSON.stringify({
-      from: "II",
-      tokens: allTokens.sort((a, b) => {
-        return a.id_number - b.id_number;
-      }),
+  async getToken(id_number: number): Promise<Token | null> {
+    return this._getTokens().find(x => x.id_number === id_number) || null;
+  }
+
+  async getTokens(): Promise<Token[]> {
+    return this._getTokens();
+  }
+
+  subscribeToAllTokens(): Observable<Token[]> {
+    return this.tokens$.asObservable();
+  }
+
+  async addToken(token: Token): Promise<void> {
+    const tokens = this._getTokens();
+    await this.setTokens([...tokens, token]);
+  }
+
+  async updateToken(id_number: number, newDoc: Token): Promise<void> {
+    await this.setTokens(this._getTokens().map((tkn) => {
+      if (tkn.id_number === id_number) {
+        return newDoc;
+      } else return tkn;
     }));
   }
 
-  async getContacts(): Promise<Contact[]> {
+  async setTokens(allTokens: Token[]): Promise<void> {
+    const tokens = allTokens.sort((a, b) => {
+      return a.id_number - b.id_number;
+    });
+    localStorage.setItem(this.authPrincipal, JSON.stringify({
+      from: "II",
+      tokens,
+    }));
+    this.tokens$.next(tokens);
+  }
+
+  private readonly contacts$: BehaviorSubject<Contact[]> = new BehaviorSubject<Contact[]>(this._getContacts());
+
+  async getContact(principal: string): Promise<Contact | null> {
+    return this._getContacts().find(x => x.principal === principal) || null;
+  }
+
+  private _getContacts(): Contact[] {
     const contactsData = JSON.parse(localStorage.getItem("contacts-" + this.authPrincipal) || "null");
     return contactsData?.contacts || [];
   }
 
-  async setContacts(contacts: Contact[]): Promise<void> {
+  async getContacts(): Promise<Contact[]> {
+    return this._getContacts();
+  }
+
+  subscribeToAllContacts(): Observable<Contact[]> {
+    return this.contacts$.asObservable();
+  }
+
+  async addContact(contact: Contact): Promise<void> {
+    const contacts = this._getContacts();
+    this.setContacts([...contacts, contact]);
+  }
+
+  async updateContact(principal: string, newDoc: Contact): Promise<void> {
+    this.setContacts(this._getContacts().map((cnts) => {
+      if (cnts.principal === principal) {
+        return newDoc;
+      } else return cnts;
+    }));
+  }
+
+  async deleteContact(principal: string): Promise<void> {
+    this.setContacts(this._getContacts().filter((cnts) => cnts.principal !== principal));
+  }
+
+  private setContacts(contacts: Contact[]) {
     localStorage.setItem(
       "contacts-" + this.authPrincipal,
       JSON.stringify({
         contacts,
       }),
-    )
+    );
+    this.contacts$.next(contacts);
   }
 
 }

--- a/frontend/database/local-storage.database.ts
+++ b/frontend/database/local-storage.database.ts
@@ -1,0 +1,53 @@
+import { IWalletDatabase } from "@/database/i-wallet-database";
+import { Token } from "@redux/models/TokenModels";
+import { Contact } from "@redux/models/ContactsModels";
+import { Identity } from "@dfinity/agent";
+
+export class LocalStorageDatabase extends IWalletDatabase {
+  private static _instance: LocalStorageDatabase | undefined;
+  public static get instance(): LocalStorageDatabase {
+    if (!this._instance) {
+      this._instance = new LocalStorageDatabase();
+    }
+    return this._instance!;
+  }
+
+  private authPrincipal = "";
+
+  init(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  setIdentity(identity: Identity | null): void {
+    this.authPrincipal = identity?.getPrincipal().toText() || "";
+  }
+
+  async getTokens(): Promise<Token[]> {
+    const userData = JSON.parse(localStorage.getItem(this.authPrincipal) || "null");
+    return userData?.tokens || [];
+  }
+
+  async setTokens(allTokens: Token[]): Promise<void> {
+    localStorage.setItem(this.authPrincipal, JSON.stringify({
+      from: "II",
+      tokens: allTokens.sort((a, b) => {
+        return a.id_number - b.id_number;
+      }),
+    }));
+  }
+
+  async getContacts(): Promise<Contact[]> {
+    const contactsData = JSON.parse(localStorage.getItem("contacts-" + this.authPrincipal) || "null");
+    return contactsData?.contacts || [];
+  }
+
+  async setContacts(contacts: Contact[]): Promise<void> {
+    localStorage.setItem(
+      "contacts-" + this.authPrincipal,
+      JSON.stringify({
+        contacts,
+      }),
+    )
+  }
+
+}

--- a/frontend/database/rxdb.database.ts
+++ b/frontend/database/rxdb.database.ts
@@ -4,7 +4,6 @@ import { Contact } from "@redux/models/ContactsModels";
 import { addRxPlugin, createRxDatabase, lastOfArray, RxCollection, RxDocument } from "rxdb";
 import { getRxStorageDexie } from "rxdb/plugins/storage-dexie";
 import { RxDBMigrationPlugin } from "rxdb/plugins/migration";
-import { Ed25519KeyIdentity } from "@dfinity/identity";
 
 import { RxDBDevModePlugin } from "rxdb/plugins/dev-mode";
 import { RxDBUpdatePlugin } from "rxdb/plugins/update";
@@ -146,7 +145,8 @@ export class RxdbDatabase extends IWalletDatabase {
   setIdentity(identity: Identity | null): void {
     this.invalidateDb();
     this.identity = identity || new AnonymousIdentity();
-    this.agent.replaceIdentity(identity || new AnonymousIdentity());
+    this.agent.replaceIdentity(this.identity);
+    this.identityChanged$.next();
   }
 
   private _mapTokenDoc(doc: RxDocument<TokenRxdbDocument>): Token {

--- a/frontend/database/rxdb.database.ts
+++ b/frontend/database/rxdb.database.ts
@@ -196,17 +196,6 @@ export class RxdbDatabase extends IWalletDatabase {
     });
   }
 
-  async setTokens(allTokens: Token[]): Promise<void> {
-    console.warn("using setTokens function to overwrite all tokens in DB at once is discouraged");
-    await (await this.tokens).bulkRemove(((await this.getTokens()) || []).map(x => "" + x.id_number));
-    await (await this.tokens).bulkInsert(allTokens.map(d => ({
-      ...d,
-      id: "" + d.id_number,
-      deleted: false,
-      updatedAt: Date.now(),
-    })));
-  }
-
   private _mapContactDoc(doc: RxDocument<ContactRxdbDocument>): Contact {
     return {
       name: doc.name,

--- a/frontend/database/rxdb.database.ts
+++ b/frontend/database/rxdb.database.ts
@@ -1,0 +1,355 @@
+import { IWalletDatabase } from "@/database/i-wallet-database";
+import { Token } from "@redux/models/TokenModels";
+import { Contact } from "@redux/models/ContactsModels";
+import { addRxPlugin, createRxDatabase, lastOfArray, RxCollection } from "rxdb";
+import { getRxStorageDexie } from "rxdb/plugins/storage-dexie";
+import { RxDBMigrationPlugin } from "rxdb/plugins/migration";
+
+import { RxDBDevModePlugin } from "rxdb/plugins/dev-mode";
+import { AnonymousIdentity, HttpAgent, Identity } from "@dfinity/agent";
+import { createActor } from "@/database/candid";
+import { replicateRxCollection, RxReplicationState } from "rxdb/plugins/replication";
+import { BehaviorSubject, combineLatest, distinctUntilChanged, map, Observable } from "rxjs";
+
+addRxPlugin(RxDBDevModePlugin);
+addRxPlugin(RxDBMigrationPlugin);
+
+type TokenRxdbDocument = Token & { id: string, updatedAt: number, deleted: boolean };
+type ContactRxdbDocument = Contact & { updatedAt: number, deleted: boolean };
+
+const setupReplication: <T extends { updatedAt: number, deleted: boolean }, PK>(
+  collection: RxCollection<T>,
+  replicationIdentifier: string,
+  primaryKey: keyof T,
+  pushFunc: (items: T[]) => Promise<void>,
+  pullFunc: (minTimestamp: number, lastId: PK | null, batchSize: number) => Promise<T[]>,
+) => [
+  RxReplicationState<any, any>,
+  number,
+  BehaviorSubject<boolean>,
+  BehaviorSubject<boolean>
+] = <T extends { updatedAt: number, deleted: boolean }, PK>(
+  collection: RxCollection<T>,
+  replicationIdentifier: string,
+  primaryKey: keyof T,
+  pushFunc: (items: T[]) => Promise<void>,
+  pullFunc: (minTimestamp: number, lastId: PK | null, batchSize: number) => Promise<T[]>,
+) => {
+  const pushing$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
+  const pulling$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
+  const tokensReplicationState = replicateRxCollection({
+    collection,
+    replicationIdentifier,
+    retryTime: 5 * 1000,
+    autoStart: false,
+    deletedField: "deleted",
+    push: {
+      handler: async (docs): Promise<any> => {
+        pushing$.next(true);
+        let store: T[] = docs.map(x => x.newDocumentState) as any;
+        try {
+          console.debug(replicationIdentifier + " replica push", store);
+          await pushFunc(store);
+          pushing$.next(false);
+        } catch (err) {
+          pushing$.next(false);
+          console.error(err);
+          throw err;
+        }
+      },
+      batchSize: 100,
+      modifier: (d) => d,
+    },
+    pull: {
+      handler: async (lastCheckpoint: any, batchSize): Promise<any> => {
+        pulling$.next(true);
+        try {
+          const documentsFromRemote = await pullFunc(lastCheckpoint ? lastCheckpoint.updatedAt : 0, lastCheckpoint?.id, batchSize);
+          console.debug(replicationIdentifier + " replica pull", documentsFromRemote);
+          pulling$.next(false);
+          return {
+            documents: documentsFromRemote,
+            checkpoint:
+              documentsFromRemote.length === 0
+                ? lastCheckpoint
+                : {
+                  id: lastOfArray(documentsFromRemote)![primaryKey],
+                  updatedAt: lastOfArray(documentsFromRemote)!.updatedAt,
+                },
+          };
+        } catch (err) {
+          pulling$.next(false);
+          console.error(err);
+          throw err;
+        }
+      },
+      batchSize: 1000,
+      modifier: (d) => d,
+    },
+  });
+  tokensReplicationState.start().then();
+  return [
+    tokensReplicationState,
+    setInterval(() => tokensReplicationState.reSync(), 15000),
+    pushing$,
+    pulling$,
+  ];
+};
+
+export class RxdbDatabase extends IWalletDatabase {
+  private static _instance: RxdbDatabase | undefined;
+  public static get instance(): RxdbDatabase {
+    if (!this._instance) {
+      this._instance = new RxdbDatabase();
+    }
+    return this._instance!;
+  }
+
+  private identity: Identity = new AnonymousIdentity();
+  private readonly agent = new HttpAgent({ identity: this.identity, host: import.meta.env.VITE_DB_CANISTER_HOST });
+  private readonly replicaCanister = createActor(import.meta.env.VITE_DB_CANISTER_ID, { agent: this.agent });
+
+  private _tokens!: RxCollection<TokenRxdbDocument>;
+  private tokensReplicationState?: RxReplicationState<any, any>;
+  private tokensPullInterval?: any;
+  private _contacts!: RxCollection<ContactRxdbDocument>;
+  private contactsReplicationState?: RxReplicationState<any, any>;
+  private contactsPullInterval?: any;
+
+  private pullingTokens$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
+  private pushingTokens$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
+  private pullingContacts$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
+  private pushingContacts$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
+
+  protected get tokens(): Promise<RxCollection<TokenRxdbDocument>> {
+    if (this._tokens) return Promise.resolve(this._tokens);
+    return this.init().then(() => this._tokens);
+  }
+
+  protected get contacts(): Promise<RxCollection<ContactRxdbDocument>> {
+    if (this._contacts) return Promise.resolve(this._contacts);
+    return this.init().then(() => this._contacts);
+  }
+
+  subscribeOnPulling(): Observable<boolean> {
+    return combineLatest([this.pullingTokens$, this.pullingContacts$]).pipe(map(([a, b]) => a || b), distinctUntilChanged());
+  }
+
+  subscribeOnPushing(): Observable<boolean> {
+    return combineLatest([this.pushingTokens$, this.pushingContacts$]).pipe(map(([a, b]) => a || b), distinctUntilChanged());
+  }
+
+  setIdentity(identity: Identity | null): void {
+    this.invalidateDb();
+    this.identity = identity || new AnonymousIdentity();
+    this.agent.replaceIdentity(identity || new AnonymousIdentity());
+  }
+
+  async getTokens(): Promise<Token[]> {
+    const documents = await (await this.tokens).find().exec();
+    return documents.map(d => ({
+      name: d.name,
+      id_number: d.id_number,
+      address: d.address,
+      logo: d.logo,
+      decimal: d.decimal,
+      symbol: d.symbol,
+      index: d.index,
+      subAccounts: d.subAccounts,
+    }));
+  }
+
+  async setTokens(allTokens: Token[]): Promise<void> {
+    console.warn("using setTokens function to overwrite all tokens in DB at once is discouraged");
+    await (await this.tokens).bulkRemove(((await this.getTokens()) || []).map(x => "" + x.id_number));
+    await (await this.tokens).bulkInsert(allTokens.map(d => ({
+      ...d,
+      id: "" + d.id_number,
+      deleted: false,
+      updatedAt: Date.now(),
+    })));
+  }
+
+  async getContacts(): Promise<Contact[]> {
+    const documents = await (await this.contacts).find().exec();
+    return documents.map(d => ({
+      name: d.name,
+      principal: d.principal,
+      accountIdentier: d.accountIdentier,
+      assets: d.assets,
+    }));
+  }
+
+  async setContacts(allContacts: Contact[]): Promise<void> {
+    console.warn("using setContacts function to overwrite all contacts in DB at once is discouraged");
+    await (await this.contacts).bulkRemove(((await this.getContacts()) || []).map(x => "" + x.name));
+    await (await this.contacts).bulkInsert(allContacts.map(x => ({
+      ...x,
+      deleted: false,
+      updatedAt: Date.now(),
+    })));
+  }
+
+  async init(): Promise<void> {
+    if (import.meta.env.VITE_DB_CANISTER_HOST!.includes("localhost") || import.meta.env.VITE_DB_CANISTER_HOST!.includes("127.0.0.1")) {
+      await this.agent.fetchRootKey();
+    }
+    const db = await createRxDatabase({
+      name: "local_db_" + this.identity.getPrincipal().toText(),
+      storage: getRxStorageDexie(),
+      ignoreDuplicate: true,
+      multiInstance: true,
+      eventReduce: true,
+      cleanupPolicy: {},
+    });
+    const { tokens, contacts } = await db.addCollections({
+      tokens: {
+        schema: {
+          type: "object",
+          version: 0,
+          primaryKey: "id",
+          properties: {
+            id: { type: "string", maxLength: 32 },
+            id_number: { type: "number" },
+            address: { type: "string", maxLength: 100 },
+            symbol: { type: "string", maxLength: 100 },
+            name: { type: "string", maxLength: 100 },
+            decimal: { type: "string", maxLength: 100 },
+            subAccounts: {
+              type: "array",
+              items: {
+                type: "record",
+                properties: {
+                  numb: { type: "string" },
+                  name: { type: "string" },
+                },
+                required: ["numb", "name"],
+              },
+            },
+            index: { type: "string", maxLength: 100 },
+            logo: { type: "string", maxLength: 100 },
+          },
+          required: ["id_number", "address", "symbol", "symbol", "name", "decimal", "subAccounts"],
+          indexes: ["name"],
+        },
+        migrationStrategies: {},
+      },
+      contacts: {
+        schema: {
+          type: "object",
+          version: 0,
+          primaryKey: "name",
+          properties: {
+            name: { type: "string", maxLength: 100 },
+            principal: { type: "string", maxLength: 100 },
+            accountIdentier: { type: "string", maxLength: 100 },
+            assets: {
+              type: "array",
+              items: {
+                type: "record",
+                properties: {
+                  symbol: { type: "string" },
+                  tokenSymbol: { type: "string" },
+                  logo: { type: "string" },
+                  subaccounts: {
+                    type: "record",
+                    properties: {
+                      name: { type: "string" },
+                      subaccount_index: { type: "string" },
+                    },
+                    required: ["name", "subaccount_index"],
+                  },
+                },
+                required: ["symbol", "tokenSymbol", "subaccounts"],
+              },
+            },
+          },
+          required: ["name", "principal", "assets"],
+        },
+        migrationStrategies: {},
+      },
+    });
+    [this.tokensReplicationState, this.tokensPullInterval, this.pushingTokens$, this.pullingTokens$] =
+      setupReplication<TokenRxdbDocument, string>(
+        tokens,
+        "tokens-" + this.identity.getPrincipal().toText(),
+        "id",
+        async (items) => {
+          const arg = items.map(x => ({
+            ...x,
+            id_number: BigInt(x.id_number),
+            updatedAt: Math.floor(Date.now() / 1000),
+            logo: (x.logo ? [x.logo] : []) as [string] | [],
+            index: (x.index ? [x.index] : []) as [string] | [],
+          }));
+          await this.replicaCanister.pushTokens(arg);
+        },
+        async (minTimestamp: number, lastId: string | null, batchSize: number) => {
+          const raw = await this.replicaCanister.pullTokens(minTimestamp, lastId ? [lastId] : [], BigInt(batchSize));
+          return raw.map(x => ({
+            ...x,
+            updatedAt: x.updatedAt,
+            deleted: x.deleted,
+            id_number: Number(x.id_number),
+            logo: x.logo[0],
+            index: x.index[0],
+          }));
+        },
+      );
+    [this.contactsReplicationState, this.contactsPullInterval, this.pushingContacts$, this.pullingContacts$] =
+      setupReplication<ContactRxdbDocument, string>(
+        contacts,
+        "contacts-" + this.identity.getPrincipal().toText(),
+        "name",
+        async (items) => {
+          const arg = items.map(x => ({
+            ...x,
+            updatedAt: Math.floor(Date.now() / 1000),
+            deleted: x.deleted,
+            assets: x.assets.map(a => ({
+              ...a,
+              logo: (a.logo ? [a.logo] : []) as ([string] | []),
+            })),
+            accountIdentier: (x.accountIdentier ? [x.accountIdentier] : []) as ([string] | []),
+          }));
+          await this.replicaCanister.pushContacts(arg);
+        },
+        async (minTimestamp: number, lastId: string | null, batchSize: number) => {
+          const raw = await this.replicaCanister.pullContacts(minTimestamp, lastId ? [lastId] : [], BigInt(batchSize));
+          const a: ContactRxdbDocument[] = raw.map(x => ({
+            ...x,
+            accountIdentier: x.accountIdentier[0],
+            assets: x.assets.map(a => ({
+              ...a,
+              logo: a.logo[0],
+            })),
+          }));
+          return a;
+        },
+      );
+    this._tokens = tokens;
+    this._contacts = contacts;
+  }
+
+  invalidateDb(): void {
+    if (this.tokensPullInterval !== undefined) {
+      clearInterval(this.tokensPullInterval);
+      this.tokensPullInterval = undefined;
+    }
+    if (this.contactsPullInterval !== undefined) {
+      clearInterval(this.contactsPullInterval);
+      this.contactsPullInterval = undefined;
+    }
+    if (this.tokensReplicationState) {
+      this.tokensReplicationState.cancel().then();
+      this.tokensReplicationState = undefined;
+    }
+    if (this.contactsReplicationState) {
+      this.contactsReplicationState.cancel().then();
+      this.contactsReplicationState = undefined;
+    }
+    this._tokens = null!;
+    this._contacts = null!;
+  }
+
+}

--- a/frontend/pages/components/topbar/index.tsx
+++ b/frontend/pages/components/topbar/index.tsx
@@ -27,6 +27,7 @@ import { useAppDispatch } from "@redux/Store";
 import { setLoading } from "@redux/assets/AssetReducer";
 import { CustomCopy } from "@components/CopyTooltip";
 import { AssetHook } from "@pages/home/hooks/assetHook";
+import { db } from "@/database/db";
 
 const TopBarComponent = () => {
   const { t } = useTranslation();
@@ -150,7 +151,7 @@ const TopBarComponent = () => {
   function changeLanguage(lang: string) {
     onLanguageChange(lang);
     i18n.changeLanguage(lang, () => {
-      localStorage.setItem("language", lang);
+      db().setLanguage(lang);
     });
   }
 };

--- a/frontend/pages/components/topbar/themeModal.tsx
+++ b/frontend/pages/components/topbar/themeModal.tsx
@@ -9,6 +9,7 @@ import { clsx } from "clsx";
 import * as RadioGroup from "@radix-ui/react-radio-group";
 import { ThemeHook } from "@pages/hooks/themeHook";
 import { ThemesEnum } from "@/const";
+import { db } from "@/database/db";
 
 interface ThemeModalProps {
   setOpen(value: boolean): void;
@@ -112,11 +113,11 @@ const ThemeModal = ({ setOpen }: ThemeModalProps) => {
     if (theme === ThemesEnum.enum.light) {
       document.documentElement.classList.remove(ThemesEnum.enum.dark);
       changeTheme(ThemesEnum.enum.light);
-      localStorage.setItem("theme", ThemesEnum.enum.light);
+      db().setTheme(ThemesEnum.enum.light);
     } else {
       document.documentElement.classList.add(ThemesEnum.enum.dark);
       changeTheme(ThemesEnum.enum.dark);
-      localStorage.setItem("theme", ThemesEnum.enum.dark);
+      db().setTheme(ThemesEnum.enum.dark);
     }
   }
 };

--- a/frontend/pages/contacts/components/tableContacts.tsx
+++ b/frontend/pages/contacts/components/tableContacts.tsx
@@ -9,7 +9,6 @@ import { useTranslation } from "react-i18next";
 import {
   AssetContact,
   Contact,
-  ContactErr,
   NewContactSubAccount,
   SubAccountContact,
   SubAccountContactErr,

--- a/frontend/pages/home/components/AddAsset.tsx
+++ b/frontend/pages/home/components/AddAsset.tsx
@@ -9,10 +9,8 @@ import { TokenHook } from "../hooks/tokenHook";
 import { Asset } from "@redux/models/AccountModels";
 import { Token } from "@redux/models/TokenModels";
 import { AssetHook } from "../hooks/assetHook";
-import { useAppDispatch } from "@redux/Store";
 import DialogAssetConfirmation from "./DialogAssetConfirmation";
 import AddAssetManual from "./AddAssetManual";
-import { addToken } from "@redux/assets/AssetReducer";
 import AddAssetAutomatic from "./AddAssetAutomatic";
 import { db } from "@/database/db";
 
@@ -26,7 +24,6 @@ interface AddAssetsProps {
 
 const AddAsset = ({ setAssetOpen, assetOpen, asset, setAssetInfo, tokens }: AddAssetsProps) => {
   const { t } = useTranslation();
-  const dispatch = useAppDispatch();
 
   const { reloadBallance } = AssetHook();
   const { checkAssetAdded } = GeneralHook();
@@ -81,7 +78,6 @@ const AddAsset = ({ setAssetOpen, assetOpen, asset, setAssetInfo, tokens }: AddA
             setAssetOpen={setAssetOpen}
             tokens={tokens}
             addAssetToData={addAssetToData}
-            saveInLocalStorage={saveInLocalStorage}
           ></AddAssetManual>
         ) : (
           <AddAssetAutomatic
@@ -133,10 +129,6 @@ const AddAsset = ({ setAssetOpen, assetOpen, asset, setAssetInfo, tokens }: AddA
     setAssetInfo(undefined);
   }
 
-  async function saveInLocalStorage(tokens: Token[]) {
-    await db().setTokens(tokens);
-  }
-
   async function addAssetToData() {
     if (checkAssetAdded(newToken.address)) {
       setErrToken(t("adding.asset.already.imported"));
@@ -154,10 +146,9 @@ const AddAsset = ({ setAssetOpen, assetOpen, asset, setAssetInfo, tokens }: AddA
         id_number: idx,
         subAccounts: [{ numb: "0x0", name: AccountDefaultEnum.Values.Default }],
       };
-      await saveInLocalStorage([...tokens, tknSave]);
+      await db().addToken(tknSave);
       setAddStatus(AddingAssetsEnum.enum.adding);
       showModal(true);
-      dispatch(addToken(tknSave));
       reloadBallance(
         [...tokens, tknSave].sort((a, b) => {
           return a.id_number - b.id_number;

--- a/frontend/pages/home/components/AddAssetManual.tsx
+++ b/frontend/pages/home/components/AddAssetManual.tsx
@@ -16,38 +16,47 @@ import { AccountDefaultEnum, IconTypeEnum } from "@/const";
 import { Asset } from "@redux/models/AccountModels";
 import { IdentityHook } from "@pages/hooks/identityHook";
 import { ChangeEvent } from "react";
+import { db } from "@/database/db";
 
 interface AddAssetManualProps {
   manual: boolean;
+
   setManual(value: boolean): void;
+
   errToken: string;
+
   setErrToken(value: string): void;
+
   validToken: boolean;
+
   setValidToken(value: boolean): void;
+
   newToken: Token;
+
   setNewToken(value: any): void;
+
   asset: Asset | undefined;
+
   setAssetOpen(value: boolean): void;
+
   tokens: Token[];
+
   addAssetToData(): void;
-  saveInLocalStorage(value: Token[]): void;
 }
 
 const AddAssetManual = ({
-  manual,
-  setManual,
-  errToken,
-  setErrToken,
-  validToken,
-  setValidToken,
-  newToken,
-  setNewToken,
-  asset,
-  setAssetOpen,
-  tokens,
-  addAssetToData,
-  saveInLocalStorage,
-}: AddAssetManualProps) => {
+                          manual,
+                          setManual,
+                          errToken,
+                          setErrToken,
+                          validToken,
+                          setValidToken,
+                          newToken,
+                          setNewToken,
+                          asset,
+                          setAssetOpen,
+                          addAssetToData,
+                        }: AddAssetManualProps) => {
   const { t } = useTranslation();
   const dispatch = useAppDispatch();
 
@@ -62,7 +71,8 @@ const AddAssetManual = ({
           <p className="text-lg font-bold mt-2">{`${asset.tokenName} - ${asset.tokenSymbol}`}</p>
         </div>
       ) : (
-        <div className="flex flex-row justify-start items-start w-full p-2 rounded-lg border border-SelectRowColor bg-SelectRowColor/10">
+        <div
+          className="flex flex-row justify-start items-start w-full p-2 rounded-lg border border-SelectRowColor bg-SelectRowColor/10">
           <InfoIcon className="h-5 w-5 fill-SelectRowColor mr-2 mt-1" />
           <p className="w-full text-justify opacity-60">
             {t("asset.add.warning.1")} <span className=" text-SelectRowColor">{t("asset.add.warning.2")}</span>
@@ -241,13 +251,10 @@ const AddAssetManual = ({
       // Change contacts local and reducer
       dispatch(editAssetName(asset.tokenSymbol, newToken.symbol));
       // List all tokens modifying the one we selected
-      const auxTokens = tokens.map((tkn) => {
-        if (tkn.id_number === newToken.id_number) {
-          return newToken;
-        } else return tkn;
-      });
-      // Save tokens in list to local
-      saveInLocalStorage(auxTokens);
+      const token = await db().getToken(newToken.id_number);
+      if (token) {
+        await db().updateToken(token.id_number, newToken);
+      }
       // Edit tokens list and assets list
       dispatch(editToken(newToken, asset.tokenSymbol));
       setAssetOpen(false);

--- a/frontend/pages/home/components/AssetElement.tsx
+++ b/frontend/pages/home/components/AssetElement.tsx
@@ -141,7 +141,6 @@ const AssetElement = ({ asset, idx, acordeonIdx, setAssetInfo, setAssetOpen, tok
         setHexChecked={setHexChecked}
         tokens={tokens}
         idx={idx}
-        authClient={authClient}
       ></DialogAddAsset>
     </Fragment>
   );

--- a/frontend/pages/home/components/DialogAddAsset.tsx
+++ b/frontend/pages/home/components/DialogAddAsset.tsx
@@ -18,29 +18,37 @@ import { db } from "@/database/db";
 
 interface DialogAddAssetProps {
   newErr: any;
+
   setNewErr(value: any): void;
+
   newSub: SubAccount | undefined;
+
   setNewSub(value: any): void;
+
   usedIdxs: string[];
+
   getLowestMissing(value: string[]): any;
+
   hexChecked: boolean;
+
   setHexChecked(value: any): void;
+
   tokens: Token[];
   idx: number;
 }
 
 const DialogAddAsset = ({
-  newErr,
-  setNewErr,
-  newSub,
-  setNewSub,
-  usedIdxs,
-  getLowestMissing,
-  hexChecked,
-  setHexChecked,
-  tokens,
-  idx,
-}: DialogAddAssetProps) => {
+                          newErr,
+                          setNewErr,
+                          newSub,
+                          setNewSub,
+                          usedIdxs,
+                          getLowestMissing,
+                          hexChecked,
+                          setHexChecked,
+                          tokens,
+                          idx,
+                        }: DialogAddAssetProps) => {
   const { t } = useTranslation();
   const dispatch = useAppDispatch();
 
@@ -150,10 +158,6 @@ const DialogAddAsset = ({
     });
   }
 
-  async function saveLocalStorage(auxTokens: Token[]) {
-    await db().setTokens(auxTokens);
-  }
-
   async function onEnter() {
     if (newSub) {
       const subClean = removeLeadingZeros(
@@ -169,23 +173,19 @@ const DialogAddAsset = ({
         errIdx = true;
       }
       if (!errName && !errIdx) {
-        const auxTokens = tokens.map((tkn, k) => {
-          if (k === Number(idx)) {
-            return {
-              ...tkn,
-              subAccounts: [
-                ...tkn.subAccounts,
-                {
-                  name: newSub.name,
-                  numb: `0x${subClean}`.toLowerCase(),
-                },
-              ].sort((a, b) => {
-                return hexToNumber(a.numb)?.compare(hexToNumber(b.numb) || bigInt()) || 0;
-              }),
-            };
-          } else return tkn;
+        const token = tokens[Number(idx)];
+        await db().updateToken(token.id_number, {
+          ...token,
+          subAccounts: [
+            ...token.subAccounts,
+            {
+              name: newSub.name,
+              numb: `0x${subClean}`.toLowerCase(),
+            },
+          ].sort((a, b) => {
+            return hexToNumber(a.numb)?.compare(hexToNumber(b.numb) || bigInt()) || 0;
+          }),
         });
-        await saveLocalStorage(auxTokens);
         dispatch(
           addSubAccount(idx, {
             ...newSub,

--- a/frontend/pages/home/components/DialogAddAsset.tsx
+++ b/frontend/pages/home/components/DialogAddAsset.tsx
@@ -14,6 +14,7 @@ import { useAppDispatch } from "@redux/Store";
 import { addSubAccount } from "@redux/assets/AssetReducer";
 import bigInt from "big-integer";
 import { ChangeEvent } from "react";
+import { db } from "@/database/db";
 
 interface DialogAddAssetProps {
   newErr: any;
@@ -26,7 +27,6 @@ interface DialogAddAssetProps {
   setHexChecked(value: any): void;
   tokens: Token[];
   idx: number;
-  authClient: string;
 }
 
 const DialogAddAsset = ({
@@ -40,7 +40,6 @@ const DialogAddAsset = ({
   setHexChecked,
   tokens,
   idx,
-  authClient,
 }: DialogAddAssetProps) => {
   const { t } = useTranslation();
   const dispatch = useAppDispatch();
@@ -151,19 +150,11 @@ const DialogAddAsset = ({
     });
   }
 
-  function saveLocalStorage(auxTokens: Token[]) {
-    localStorage.setItem(
-      authClient,
-      JSON.stringify({
-        from: "II",
-        tokens: auxTokens.sort((a, b) => {
-          return a.id_number - b.id_number;
-        }),
-      }),
-    );
+  async function saveLocalStorage(auxTokens: Token[]) {
+    await db().setTokens(auxTokens);
   }
 
-  function onEnter() {
+  async function onEnter() {
     if (newSub) {
       const subClean = removeLeadingZeros(
         newSub.sub_account_id.slice(0, 2).toLowerCase() === "0x"
@@ -194,7 +185,7 @@ const DialogAddAsset = ({
             };
           } else return tkn;
         });
-        saveLocalStorage(auxTokens);
+        await saveLocalStorage(auxTokens);
         dispatch(
           addSubAccount(idx, {
             ...newSub,

--- a/frontend/pages/hooks/languageHook.tsx
+++ b/frontend/pages/hooks/languageHook.tsx
@@ -6,14 +6,15 @@ import { ReactComponent as BrazilFlag } from "../../assets/svg/files/brazil.svg"
 //
 import { useEffect, useState } from "react";
 import i18n from "../../i18n";
+import { db } from "@/database/db";
 
 export const LanguageHook = () => {
   const [languageMenu, setLanguageMenu] = useState<any>({
-    code: localStorage.language ? localStorage.language : "en",
+    code: db().getLanguage() || "en",
   });
 
   const changeLocalLanguage = (e: string) => {
-    localStorage.setItem("language", e);
+    db().setLanguage(e);
   };
 
   const languageOptionTemplate = () => {

--- a/frontend/pages/hooks/workerHook.tsx
+++ b/frontend/pages/hooks/workerHook.tsx
@@ -3,7 +3,7 @@ import { hexToUint8Array } from "@/utils";
 // import { AssetList, Metadata } from "@candid/metadata/service.did";
 import store, { useAppSelector } from "@redux/Store";
 import { getAllTransactionsICP, getAllTransactionsICRC1, updateAllBalances } from "@redux/assets/AssetActions";
-import { setTokens, setTxWorker } from "@redux/assets/AssetReducer";
+import { setTxWorker } from "@redux/assets/AssetReducer";
 import { Asset, SubAccount } from "@redux/models/AccountModels";
 import { Token } from "@redux/models/TokenModels";
 import timer_script from "@workers/timerWorker";
@@ -59,11 +59,9 @@ export const WorkerHook = () => {
   const getAssetsWorker = async () => {
     const dbTokens = await db().getTokens();
     if (dbTokens) {
-      store.dispatch(setTokens(tokens));
       await updateAllBalances(true, userAgent, dbTokens);
     } else {
-      const { tokens } = await updateAllBalances(true, userAgent, defaultTokens, true);
-      store.dispatch(setTokens(tokens));
+      await updateAllBalances(true, userAgent, defaultTokens, true);
     }
   };
 

--- a/frontend/pages/hooks/workerHook.tsx
+++ b/frontend/pages/hooks/workerHook.tsx
@@ -1,4 +1,4 @@
-import { AssetSymbolEnum, WorkerTaskEnum, defaultTokens } from "@/const";
+import { AssetSymbolEnum, defaultTokens, WorkerTaskEnum } from "@/const";
 import { hexToUint8Array } from "@/utils";
 // import { AssetList, Metadata } from "@candid/metadata/service.did";
 import store, { useAppSelector } from "@redux/Store";
@@ -8,10 +8,11 @@ import { Asset, SubAccount } from "@redux/models/AccountModels";
 import { Token } from "@redux/models/TokenModels";
 import timer_script from "@workers/timerWorker";
 import { useEffect } from "react";
+import { db } from "@/database/db";
 
 export const WorkerHook = () => {
   const { tokens, assets, txWorker } = useAppSelector((state) => state.asset);
-  const { authClient, userAgent } = useAppSelector((state) => state.auth);
+  const { userAgent } = useAppSelector((state) => state.auth);
 
   const getTransactionsWorker = async () => {
     assets.map((elementA: Asset) => {
@@ -56,11 +57,10 @@ export const WorkerHook = () => {
   };
 
   const getAssetsWorker = async () => {
-    const userData = localStorage.getItem(authClient);
-    if (userData) {
-      const userDataJson = JSON.parse(userData);
-      store.dispatch(setTokens(userDataJson.tokens));
-      await updateAllBalances(true, userAgent, userDataJson.tokens);
+    const dbTokens = await db().getTokens();
+    if (dbTokens) {
+      store.dispatch(setTokens(tokens));
+      await updateAllBalances(true, userAgent, dbTokens);
     } else {
       const { tokens } = await updateAllBalances(true, userAgent, defaultTokens, true);
       store.dispatch(setTokens(tokens));

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -10,6 +10,8 @@ import { useAppSelector } from "@redux/Store";
 import { ThemeHook } from "./hooks/themeHook";
 import Loader from "./components/Loader";
 import { ThemesEnum } from "@/const";
+import { db } from "@/database/db";
+
 const Home = lazy(() => import("./home"));
 const Contacts = lazy(() => import("./contacts"));
 
@@ -18,16 +20,17 @@ const SwitchRoute = () => {
   const { blur } = useAppSelector((state) => state.auth);
   const { changeTheme } = ThemeHook();
   useEffect(() => {
+    const theme = db().getTheme();
     if (
-      localStorage.theme === ThemesEnum.enum.dark ||
-      (!("theme" in localStorage) && window.matchMedia("(prefers-color-scheme: dark)").matches)
+      theme === ThemesEnum.enum.dark ||
+      (theme === null && window.matchMedia("(prefers-color-scheme: dark)").matches)
     ) {
       document.documentElement.classList.add(ThemesEnum.enum.dark);
-      localStorage.theme = ThemesEnum.enum.dark;
+      db().setTheme(ThemesEnum.enum.dark);
       changeTheme(ThemesEnum.enum.dark);
     } else {
       document.documentElement.classList.remove(ThemesEnum.enum.dark);
-      localStorage.theme = ThemesEnum.enum.light;
+      db().setTheme(ThemesEnum.enum.light);
       changeTheme(ThemesEnum.enum.light);
     }
   }, []);

--- a/frontend/pages/login/index.tsx
+++ b/frontend/pages/login/index.tsx
@@ -12,6 +12,7 @@ import { Fragment } from "react";
 import { handleAuthenticated } from "@/redux/CheckAuth";
 import { AuthNetworkTypeEnum, ThemesEnum } from "@/const";
 import { AuthNetwork } from "@redux/models/TokenModels";
+import { db } from "@/database/db";
 
 const Login = () => {
   const { t } = useTranslation();
@@ -81,7 +82,7 @@ const Login = () => {
 
   async function handleLogin(opt: AuthNetwork) {
     if (opt.type === AuthNetworkTypeEnum.Values.IC || opt.type === AuthNetworkTypeEnum.Values.NFID) {
-      localStorage.setItem("network_type", JSON.stringify({ type: opt.type, network: opt.network, name: opt.name }));
+      db().setNetworkType(opt);
       handleAuthenticated(opt);
     }
   }

--- a/frontend/redux/CheckAuth.tsx
+++ b/frontend/redux/CheckAuth.tsx
@@ -3,8 +3,8 @@ import { HttpAgent, Identity } from "@dfinity/agent";
 import store from "./Store";
 import {
   clearDataAuth,
-  setAuthLoading,
   setAuthenticated,
+  setAuthLoading,
   setUnauthenticated,
   setUserAgent,
   setUserPrincipal,
@@ -14,7 +14,8 @@ import { updateAllBalances } from "./assets/AssetActions";
 import { clearDataAsset, setTokens } from "./assets/AssetReducer";
 import { AuthNetwork } from "./models/TokenModels";
 import { AuthNetworkTypeEnum, defaultTokens } from "@/const";
-import { clearDataContacts, setContacts, setStorageCode } from "./contacts/ContactsReducer";
+import { clearDataContacts, setContacts } from "./contacts/ContactsReducer";
+import { db } from "@/database/db";
 
 const AUTH_PATH = `/authenticate/?applicationName=${import.meta.env.VITE_APP_NAME}&applicationLogo=${
   import.meta.env.VITE_APP_LOGO
@@ -43,8 +44,10 @@ export const handleAuthenticated = async (opt: AuthNetwork) => {
 };
 
 export const handleLoginApp = async (authIdentity: Identity) => {
-  if (localStorage.getItem("network_type") === null) logout();
-  const opt: AuthNetwork = JSON.parse(localStorage.getItem("network_type") || "");
+  const opt: AuthNetwork | null = db().getNetworkType();
+  if (opt === null) logout();
+
+  db().setIdentity(authIdentity);
 
   store.dispatch(setAuthLoading(true));
   const myAgent = new HttpAgent({
@@ -58,25 +61,22 @@ export const handleLoginApp = async (authIdentity: Identity) => {
   const myPrincipal = await myAgent.getPrincipal();
 
   // TOKENS
-  const userData = localStorage.getItem(authIdentity.getPrincipal().toString());
-  if (userData) {
-    const userDataJson = JSON.parse(userData);
-    store.dispatch(setTokens(userDataJson.tokens));
-    await updateAllBalances(true, myAgent, userDataJson.tokens);
+  const dbTokens = await db().getTokens();
+  if (dbTokens) {
+    store.dispatch(setTokens(dbTokens));
+    await updateAllBalances(true, myAgent, dbTokens);
   } else {
     const { tokens } = await updateAllBalances(true, myAgent, defaultTokens, true);
     store.dispatch(setTokens(tokens));
   }
 
   // CONTACTS
-  const contactsData = localStorage.getItem("contacts-" + authIdentity.getPrincipal().toString());
-  if (contactsData) {
-    const contactsDataJson = JSON.parse(contactsData);
-    store.dispatch(setContacts(contactsDataJson.contacts));
+  const contacts = await db().getContacts();
+  if (contacts) {
+    store.dispatch(setContacts(contacts));
   }
 
   store.dispatch(setAuthenticated(true, false, authIdentity.getPrincipal().toText().toLowerCase()));
-  store.dispatch(setStorageCode("contacts-" + authIdentity.getPrincipal().toText().toLowerCase()));
   store.dispatch(setUserAgent(myAgent));
   store.dispatch(setUserPrincipal(myPrincipal));
 };
@@ -87,6 +87,7 @@ export const logout = async () => {
   store.dispatch({
     type: "USER_LOGGED_OUT",
   });
+  db().setIdentity(null);
   store.dispatch(clearDataContacts());
   store.dispatch(clearDataAsset());
   store.dispatch(clearDataAuth());

--- a/frontend/redux/CheckAuth.tsx
+++ b/frontend/redux/CheckAuth.tsx
@@ -11,10 +11,10 @@ import {
 } from "./auth/AuthReducer";
 import { AuthClient } from "@dfinity/auth-client";
 import { updateAllBalances } from "./assets/AssetActions";
-import { clearDataAsset, setTokens } from "./assets/AssetReducer";
+import { clearDataAsset } from "./assets/AssetReducer";
 import { AuthNetwork } from "./models/TokenModels";
 import { AuthNetworkTypeEnum, defaultTokens } from "@/const";
-import { clearDataContacts, setContacts } from "./contacts/ContactsReducer";
+import { clearDataContacts } from "./contacts/ContactsReducer";
 import { db } from "@/database/db";
 
 const AUTH_PATH = `/authenticate/?applicationName=${import.meta.env.VITE_APP_NAME}&applicationLogo=${
@@ -63,17 +63,9 @@ export const handleLoginApp = async (authIdentity: Identity) => {
   // TOKENS
   const dbTokens = await db().getTokens();
   if (dbTokens) {
-    store.dispatch(setTokens(dbTokens));
     await updateAllBalances(true, myAgent, dbTokens);
   } else {
-    const { tokens } = await updateAllBalances(true, myAgent, defaultTokens, true);
-    store.dispatch(setTokens(tokens));
-  }
-
-  // CONTACTS
-  const contacts = await db().getContacts();
-  if (contacts) {
-    store.dispatch(setContacts(contacts));
+    await updateAllBalances(true, myAgent, defaultTokens, true);
   }
 
   store.dispatch(setAuthenticated(true, false, authIdentity.getPrincipal().toText().toLowerCase()));

--- a/frontend/redux/assets/AssetActions.tsx
+++ b/frontend/redux/assets/AssetActions.tsx
@@ -201,9 +201,7 @@ export const updateAllBalances = async (
 
   if (loading) {
     store.dispatch(setAssets(assets));
-    if (newTokens.length !== 0) {
-      await db().setTokens(newTokens);
-    }
+    await Promise.all(newTokens.map(t => db().updateToken(t.id_number, t)));
   }
 
   const icpAsset = assets.find((ast) => ast.tokenSymbol === "ICP");

--- a/frontend/redux/assets/AssetActions.tsx
+++ b/frontend/redux/assets/AssetActions.tsx
@@ -3,20 +3,21 @@ import store from "@redux/Store";
 import { Token, TokenMarketInfo, TokenSubAccount } from "@redux/models/TokenModels";
 import { IcrcAccount, IcrcIndexCanister, IcrcLedgerCanister } from "@dfinity/ledger";
 import {
-  formatIcpTransaccion,
-  getSubAccountArray,
-  getMetadataInfo,
   formatckBTCTransaccion,
+  formatIcpTransaccion,
+  getMetadataInfo,
+  getSubAccountArray,
   getUSDfromToken,
-  hexToUint8Array,
   hexToNumber,
+  hexToUint8Array,
 } from "@/utils";
-import { setAssets, setTransactions, setTokenMarket, setICPSubaccounts } from "./AssetReducer";
+import { setAssets, setICPSubaccounts, setTokenMarket, setTransactions } from "./AssetReducer";
 import { AccountIdentifier, SubAccount as SubAccountNNS } from "@dfinity/nns";
 import { Asset, ICPSubAccount, SubAccount } from "@redux/models/AccountModels";
 import { Principal } from "@dfinity/principal";
 import { AccountDefaultEnum } from "@/const";
 import bigInt from "big-integer";
+import { db } from "@/database/db";
 
 export const updateAllBalances = async (
   loading: boolean,
@@ -201,15 +202,7 @@ export const updateAllBalances = async (
   if (loading) {
     store.dispatch(setAssets(assets));
     if (newTokens.length !== 0) {
-      localStorage.setItem(
-        myPrincipal.toString(),
-        JSON.stringify({
-          from: "II",
-          tokens: newTokens.sort((a, b) => {
-            return a.id_number - b.id_number;
-          }),
-        }),
-      );
+      await db().setTokens(newTokens);
     }
   }
 

--- a/frontend/redux/assets/AssetReducer.tsx
+++ b/frontend/redux/assets/AssetReducer.tsx
@@ -3,6 +3,8 @@ import { Token, TokenMarketInfo } from "@redux/models/TokenModels";
 import { Asset, ICPSubAccount, SubAccount, Transaction, TransactionList } from "@redux/models/AccountModels";
 import bigInt from "big-integer";
 import { hexToNumber } from "@/utils";
+import { db } from "@/database/db";
+import store from "@redux/Store";
 
 interface AssetState {
   ICPSubaccounts: Array<ICPSubAccount>;
@@ -40,17 +42,14 @@ const assetSlice = createSlice({
   name: "auth",
   initialState,
   reducers: {
+    setReduxTokens(state, action: PayloadAction<Token[]>) {
+      state.tokens = action.payload;
+    },
     setICPSubaccounts(state, action: PayloadAction<ICPSubAccount[]>) {
       state.ICPSubaccounts = action.payload;
     },
     setLoading(state, action: PayloadAction<boolean>) {
       state.assetLoading = action.payload;
-    },
-    setTokens(state, action: PayloadAction<Token[]>) {
-      state.tokens = action.payload;
-    },
-    addToken(state, action: PayloadAction<Token>) {
-      state.tokens.push(action.payload);
     },
     editToken: {
       reducer(
@@ -225,12 +224,12 @@ const assetSlice = createSlice({
   },
 });
 
+db().subscribeToAllTokens().subscribe(x => store.dispatch(assetSlice.actions.setReduxTokens(x)));
+
 export const {
   clearDataAsset,
   setICPSubaccounts,
   setLoading,
-  setTokens,
-  addToken,
   editToken,
   setTokenMarket,
   setSubAccountName,

--- a/frontend/redux/contacts/ContactsReducer.tsx
+++ b/frontend/redux/contacts/ContactsReducer.tsx
@@ -2,13 +2,12 @@ import { getAccountIdentifier, hexToNumber } from "@/utils";
 import { AssetContact, Contact } from "@redux/models/ContactsModels";
 import { PayloadAction, createSlice } from "@reduxjs/toolkit";
 import bigInt from "big-integer";
+import { db } from "@/database/db";
 
 interface ContactsState {
-  storageCode: string;
   contacts: Contact[];
 }
 const initialState: ContactsState = {
-  storageCode: "",
   contacts: [],
 };
 
@@ -16,24 +15,21 @@ const contactsSlice = createSlice({
   name: "contacts",
   initialState,
   reducers: {
-    setStorageCode(state, action: PayloadAction<string>) {
-      state.storageCode = action.payload;
-    },
     setContacts(state, action: PayloadAction<Contact[]>) {
       state.contacts = action.payload;
 
-      setLocalContacts(action.payload, state.storageCode);
+      db().setContacts(action.payload).then();
     },
     addContact(state, action: PayloadAction<Contact>) {
       const auxContact = { ...action.payload, accountIdentier: getAccountIdentifier(action.payload.principal, 0) };
       const auxContacts = [...state.contacts, auxContact];
       state.contacts = auxContacts;
-      setLocalContacts(auxContacts, state.storageCode);
+      db().setContacts(auxContacts).then();
     },
     deleteContatc(state, action: PayloadAction<string>) {
       const auxContacts = state.contacts.filter((cnts) => cnts.principal !== action.payload);
       state.contacts = auxContacts;
-      setLocalContacts(auxContacts, state.storageCode);
+      db().setContacts(auxContacts).then();
     },
     editContact: {
       reducer(
@@ -49,7 +45,7 @@ const contactsSlice = createSlice({
           } else return cnts;
         });
         state.contacts = auxContacts;
-        setLocalContacts(auxContacts, state.storageCode);
+        db().setContacts(auxContacts).then();
       },
       prepare(editedContact: Contact, pastPrincipal: string) {
         return {
@@ -72,7 +68,7 @@ const contactsSlice = createSlice({
         });
 
         state.contacts = auxContacts;
-        setLocalContacts(auxContacts, state.storageCode);
+        db().setContacts(auxContacts).then();
       },
       prepare(asset: AssetContact[], pastPrincipal: string) {
         return {
@@ -100,7 +96,7 @@ const contactsSlice = createSlice({
         });
 
         state.contacts = auxContacts;
-        setLocalContacts(auxContacts, state.storageCode);
+        db().setContacts(auxContacts).then();
       },
       prepare(tokenSymbol: string, symbol: string) {
         return {
@@ -145,7 +141,7 @@ const contactsSlice = createSlice({
           }
         });
         state.contacts = auxContacts;
-        setLocalContacts(auxContacts, state.storageCode);
+        db().setContacts(auxContacts).then();
       },
       prepare(principal: string, tokenSymbol: string, newName: string, newIndex: string) {
         return {
@@ -198,7 +194,7 @@ const contactsSlice = createSlice({
           }
         });
         state.contacts = auxContacts;
-        setLocalContacts(auxContacts, state.storageCode);
+        db().setContacts(auxContacts).then();
       },
       prepare(principal: string, tokenSymbol: string, subIndex: string, newName: string, newIndex: string) {
         return {
@@ -216,7 +212,7 @@ const contactsSlice = createSlice({
         const auxContacts = state.contacts.filter((cnts) => cnts.principal !== action.payload.principal);
 
         state.contacts = auxContacts;
-        setLocalContacts(auxContacts, state.storageCode);
+        db().setContacts(auxContacts).then();
       },
       prepare(principal: string) {
         return {
@@ -240,7 +236,7 @@ const contactsSlice = createSlice({
         });
 
         state.contacts = auxContacts;
-        setLocalContacts(auxContacts, state.storageCode);
+        db().setContacts(auxContacts).then();
       },
       prepare(principal: string, tokenSymbol: string) {
         return {
@@ -276,7 +272,7 @@ const contactsSlice = createSlice({
           }
         });
         state.contacts = auxContacts;
-        setLocalContacts(auxContacts, state.storageCode);
+        db().setContacts(auxContacts).then();
       },
       prepare(principal: string, tokenSymbol: string, subIndex: string) {
         return {
@@ -286,23 +282,12 @@ const contactsSlice = createSlice({
     },
     clearDataContacts(state) {
       state.contacts = [];
-      state.storageCode = "";
     },
   },
 });
 
-const setLocalContacts = (contacts: Contact[], code: string) => {
-  localStorage.setItem(
-    code,
-    JSON.stringify({
-      contacts: contacts,
-    }),
-  );
-};
-
 export const {
   clearDataContacts,
-  setStorageCode,
   setContacts,
   addContact,
   deleteContatc,

--- a/frontend/redux/contacts/ContactsReducer.tsx
+++ b/frontend/redux/contacts/ContactsReducer.tsx
@@ -1,12 +1,14 @@
 import { getAccountIdentifier, hexToNumber } from "@/utils";
 import { AssetContact, Contact } from "@redux/models/ContactsModels";
-import { PayloadAction, createSlice } from "@reduxjs/toolkit";
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import bigInt from "big-integer";
 import { db } from "@/database/db";
+import store from "@redux/Store";
 
 interface ContactsState {
   contacts: Contact[];
 }
+
 const initialState: ContactsState = {
   contacts: [],
 };
@@ -15,37 +17,24 @@ const contactsSlice = createSlice({
   name: "contacts",
   initialState,
   reducers: {
-    setContacts(state, action: PayloadAction<Contact[]>) {
+    setReduxContacts(state, action: PayloadAction<Contact[]>) {
       state.contacts = action.payload;
-
-      db().setContacts(action.payload).then();
     },
-    addContact(state, action: PayloadAction<Contact>) {
-      const auxContact = { ...action.payload, accountIdentier: getAccountIdentifier(action.payload.principal, 0) };
-      const auxContacts = [...state.contacts, auxContact];
-      state.contacts = auxContacts;
-      db().setContacts(auxContacts).then();
+    addContact(_, action: PayloadAction<Contact>) {
+      db().addContact({ ...action.payload, accountIdentier: getAccountIdentifier(action.payload.principal, 0) }).then();
     },
-    deleteContatc(state, action: PayloadAction<string>) {
-      const auxContacts = state.contacts.filter((cnts) => cnts.principal !== action.payload);
-      state.contacts = auxContacts;
-      db().setContacts(auxContacts).then();
+    deleteContatc(_, action: PayloadAction<string>) {
+      db().deleteContact(action.payload).then();
     },
     editContact: {
       reducer(
-        state,
+        _,
         action: PayloadAction<{
           editedContact: Contact;
           pastPrincipal: string;
         }>,
       ) {
-        const auxContacts = state.contacts.map((cnts) => {
-          if (cnts.principal === action.payload.pastPrincipal) {
-            return action.payload.editedContact;
-          } else return cnts;
-        });
-        state.contacts = auxContacts;
-        db().setContacts(auxContacts).then();
+        db().updateContact(action.payload.pastPrincipal, action.payload.editedContact).then();
       },
       prepare(editedContact: Contact, pastPrincipal: string) {
         return {
@@ -55,20 +44,20 @@ const contactsSlice = createSlice({
     },
     addAssetToContact: {
       reducer(
-        state,
+        _,
         action: PayloadAction<{
           asset: AssetContact[];
           pastPrincipal: string;
         }>,
       ) {
-        const auxContacts = state.contacts.map((cnts) => {
-          if (cnts.principal === action.payload.pastPrincipal) {
-            return { ...cnts, assets: [...cnts.assets, ...action.payload.asset] };
-          } else return cnts;
+        db().getContact(action.payload.pastPrincipal).then(async (cnt) => {
+          if (cnt) {
+            await db().updateContact(action.payload.pastPrincipal, {
+              ...cnt,
+              assets: [...cnt.assets, ...action.payload.asset],
+            });
+          }
         });
-
-        state.contacts = auxContacts;
-        db().setContacts(auxContacts).then();
       },
       prepare(asset: AssetContact[], pastPrincipal: string) {
         return {
@@ -78,25 +67,31 @@ const contactsSlice = createSlice({
     },
     editAssetName: {
       reducer(
-        state,
+        _,
         action: PayloadAction<{
           tokenSymbol: string;
           symbol: string;
         }>,
       ) {
-        const auxContacts = state.contacts.map((cnts) => {
-          return {
-            ...cnts,
-            assets: cnts.assets.map((asst) => {
-              if (asst.tokenSymbol === action.payload.tokenSymbol) {
-                return { ...asst, symbol: action.payload.symbol };
-              } else return asst;
-            }),
-          };
-        });
-
-        state.contacts = auxContacts;
-        db().setContacts(auxContacts).then();
+        setTimeout(async () => {
+          const affectedContacts: Contact[] = [];
+          for (const cnt of await db().getContacts()) {
+            let affected = false;
+            const newDoc = {
+              ...cnt,
+              assets: cnt.assets.map((asst) => {
+                if (asst.tokenSymbol === action.payload.tokenSymbol) {
+                  affected = true;
+                  return { ...asst, symbol: action.payload.symbol };
+                } else return asst;
+              }),
+            };
+            if (affected) {
+              affectedContacts.push(newDoc);
+            }
+          }
+          await Promise.all(affectedContacts.map(c => db().updateContact(c.principal, c)));
+        }, 0);
       },
       prepare(tokenSymbol: string, symbol: string) {
         return {
@@ -106,7 +101,7 @@ const contactsSlice = createSlice({
     },
     addContactSubacc: {
       reducer(
-        state,
+        _,
         action: PayloadAction<{
           principal: string;
           tokenSymbol: string;
@@ -114,12 +109,11 @@ const contactsSlice = createSlice({
           newIndex: string;
         }>,
       ) {
-        const auxContacts = state.contacts.map((cnts) => {
-          if (cnts.principal !== action.payload.principal) return cnts;
-          else {
-            return {
-              ...cnts,
-              assets: cnts.assets.map((asst) => {
+        db().getContact(action.payload.principal).then(async (cnt) => {
+          if (cnt) {
+            await db().updateContact(action.payload.principal, {
+              ...cnt,
+              assets: cnt.assets.map((asst) => {
                 if (asst.tokenSymbol !== action.payload.tokenSymbol) {
                   return asst;
                 } else {
@@ -137,11 +131,9 @@ const contactsSlice = createSlice({
                   };
                 }
               }),
-            };
+            });
           }
         });
-        state.contacts = auxContacts;
-        db().setContacts(auxContacts).then();
       },
       prepare(principal: string, tokenSymbol: string, newName: string, newIndex: string) {
         return {
@@ -151,7 +143,7 @@ const contactsSlice = createSlice({
     },
     editContactSubacc: {
       reducer(
-        state,
+        _,
         action: PayloadAction<{
           principal: string;
           tokenSymbol: string;
@@ -160,10 +152,9 @@ const contactsSlice = createSlice({
           newIndex: string;
         }>,
       ) {
-        const auxContacts = state.contacts.map((cnts) => {
-          if (cnts.principal !== action.payload.principal) return cnts;
-          else {
-            return {
+        db().getContact(action.payload.principal).then(async cnts => {
+          if (cnts) {
+            await db().updateContact(action.payload.principal, {
               ...cnts,
               assets: cnts.assets.map((asst) => {
                 if (asst.tokenSymbol !== action.payload.tokenSymbol) {
@@ -190,11 +181,9 @@ const contactsSlice = createSlice({
                   };
                 }
               }),
-            };
+            });
           }
         });
-        state.contacts = auxContacts;
-        db().setContacts(auxContacts).then();
       },
       prepare(principal: string, tokenSymbol: string, subIndex: string, newName: string, newIndex: string) {
         return {
@@ -204,15 +193,12 @@ const contactsSlice = createSlice({
     },
     removeContact: {
       reducer(
-        state,
+        _,
         action: PayloadAction<{
           principal: string;
         }>,
       ) {
-        const auxContacts = state.contacts.filter((cnts) => cnts.principal !== action.payload.principal);
-
-        state.contacts = auxContacts;
-        db().setContacts(auxContacts).then();
+        db().deleteContact(action.payload.principal).then();
       },
       prepare(principal: string) {
         return {
@@ -222,21 +208,20 @@ const contactsSlice = createSlice({
     },
     removeContactAsset: {
       reducer(
-        state,
+        _,
         action: PayloadAction<{
           principal: string;
           tokenSymbol: string;
         }>,
       ) {
-        const auxContacts = state.contacts.map((cnts) => {
-          if (cnts.principal !== action.payload.principal) return cnts;
-          else {
-            return { ...cnts, assets: cnts.assets.filter((asst) => asst.tokenSymbol !== action.payload.tokenSymbol) };
+        db().getContact(action.payload.principal).then(async (cnt) => {
+          if (cnt) {
+            await db().updateContact(action.payload.principal, {
+              ...cnt,
+              assets: cnt.assets.filter((asst) => asst.tokenSymbol !== action.payload.tokenSymbol),
+            });
           }
         });
-
-        state.contacts = auxContacts;
-        db().setContacts(auxContacts).then();
       },
       prepare(principal: string, tokenSymbol: string) {
         return {
@@ -246,19 +231,18 @@ const contactsSlice = createSlice({
     },
     removeContactSubacc: {
       reducer(
-        state,
+        _,
         action: PayloadAction<{
           principal: string;
           tokenSymbol: string;
           subIndex: string;
         }>,
       ) {
-        const auxContacts = state.contacts.map((cnts) => {
-          if (cnts.principal !== action.payload.principal) return cnts;
-          else {
-            return {
-              ...cnts,
-              assets: cnts.assets.map((asst) => {
+        db().getContact(action.payload.principal).then(async (cnt) => {
+          if (cnt) {
+            await db().updateContact(action.payload.principal, {
+              ...cnt,
+              assets: cnt.assets.map((asst) => {
                 if (asst.tokenSymbol !== action.payload.tokenSymbol) {
                   return asst;
                 } else {
@@ -268,11 +252,9 @@ const contactsSlice = createSlice({
                   };
                 }
               }),
-            };
+            });
           }
         });
-        state.contacts = auxContacts;
-        db().setContacts(auxContacts).then();
       },
       prepare(principal: string, tokenSymbol: string, subIndex: string) {
         return {
@@ -286,9 +268,10 @@ const contactsSlice = createSlice({
   },
 });
 
+db().subscribeToAllContacts().subscribe(x => store.dispatch(contactsSlice.actions.setReduxContacts(x)));
+
 export const {
   clearDataContacts,
-  setContacts,
   addContact,
   deleteContatc,
   editContact,

--- a/mops.toml
+++ b/mops.toml
@@ -1,0 +1,4 @@
+[dependencies]
+base = "0.9.3"
+rxmodb = "0.1.4"
+vector = "0.2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "react-redux": "^7.2.5",
         "react-router-dom": "^5.3.4",
         "react-scripts": "^5.0.1",
+        "rxdb": "^14.17.1",
         "sass": "^1.39.0",
         "twin.macro": "^3.1.0",
         "typescript": "^5.0.2",
@@ -2013,15 +2014,20 @@
       "integrity": "sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA=="
     },
     "node_modules/@babel/runtime": {
-      "version": "7.22.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.3.tgz",
-      "integrity": "sha512-XsDuspWKLUsxwCp6r7EhsExHtYfbe5oAGQ19kqngTdCPUoPQzOPdUbD/pB9PJiwb2ptYKQDjSJT3R6dC+EPqfQ==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.15.tgz",
+      "integrity": "sha512-T0O+aa+4w0u06iNmapipJXMV4HoUir03hpx3/YqXXhu9xim3w+dVphjFWl1OH8NbZHw5Lbm9k45drDkgq2VNNA==",
       "dependencies": {
-        "regenerator-runtime": "^0.13.11"
+        "regenerator-runtime": "^0.14.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@babel/runtime/node_modules/regenerator-runtime": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
+      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
     },
     "node_modules/@babel/template": {
       "version": "7.22.5",
@@ -2749,6 +2755,724 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@firebase/analytics": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.10.0.tgz",
+      "integrity": "sha512-Locv8gAqx0e+GX/0SI3dzmBY5e9kjVDtD+3zCFLJ0tH2hJwuCAiL+5WkHuxKj92rqQj/rvkBUCfA1ewlX2hehg==",
+      "dependencies": {
+        "@firebase/component": "0.6.4",
+        "@firebase/installations": "0.6.4",
+        "@firebase/logger": "0.4.0",
+        "@firebase/util": "1.9.3",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics-compat": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-compat/-/analytics-compat-0.2.6.tgz",
+      "integrity": "sha512-4MqpVLFkGK7NJf/5wPEEP7ePBJatwYpyjgJ+wQHQGHfzaCDgntOnl9rL2vbVGGKCnRqWtZDIWhctB86UWXaX2Q==",
+      "dependencies": {
+        "@firebase/analytics": "0.10.0",
+        "@firebase/analytics-types": "0.8.0",
+        "@firebase/component": "0.6.4",
+        "@firebase/util": "1.9.3",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics-compat/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
+    "node_modules/@firebase/analytics-types": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.8.0.tgz",
+      "integrity": "sha512-iRP+QKI2+oz3UAh4nPEq14CsEjrjD6a5+fuypjScisAh9kXKFvdJOZJDwk7kikLvWVLGEs9+kIUS4LPQV7VZVw=="
+    },
+    "node_modules/@firebase/analytics/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
+    "node_modules/@firebase/app": {
+      "version": "0.9.13",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.9.13.tgz",
+      "integrity": "sha512-GfiI1JxJ7ecluEmDjPzseRXk/PX31hS7+tjgBopL7XjB2hLUdR+0FTMXy2Q3/hXezypDvU6or7gVFizDESrkXw==",
+      "dependencies": {
+        "@firebase/component": "0.6.4",
+        "@firebase/logger": "0.4.0",
+        "@firebase/util": "1.9.3",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@firebase/app-check": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.8.0.tgz",
+      "integrity": "sha512-dRDnhkcaC2FspMiRK/Vbp+PfsOAEP6ZElGm9iGFJ9fDqHoPs0HOPn7dwpJ51lCFi1+2/7n5pRPGhqF/F03I97g==",
+      "dependencies": {
+        "@firebase/component": "0.6.4",
+        "@firebase/logger": "0.4.0",
+        "@firebase/util": "1.9.3",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/app-check-compat": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-compat/-/app-check-compat-0.3.7.tgz",
+      "integrity": "sha512-cW682AxsyP1G+Z0/P7pO/WT2CzYlNxoNe5QejVarW2o5ZxeWSSPAiVEwpEpQR/bUlUmdeWThYTMvBWaopdBsqw==",
+      "dependencies": {
+        "@firebase/app-check": "0.8.0",
+        "@firebase/app-check-types": "0.5.0",
+        "@firebase/component": "0.6.4",
+        "@firebase/logger": "0.4.0",
+        "@firebase/util": "1.9.3",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/app-check-compat/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
+    "node_modules/@firebase/app-check-interop-types": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-interop-types/-/app-check-interop-types-0.3.0.tgz",
+      "integrity": "sha512-xAxHPZPIgFXnI+vb4sbBjZcde7ZluzPPaSK7Lx3/nmuVk4TjZvnL8ONnkd4ERQKL8WePQySU+pRcWkh8rDf5Sg=="
+    },
+    "node_modules/@firebase/app-check-types": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-types/-/app-check-types-0.5.0.tgz",
+      "integrity": "sha512-uwSUj32Mlubybw7tedRzR24RP8M8JUVR3NPiMk3/Z4bCmgEKTlQBwMXrehDAZ2wF+TsBq0SN1c6ema71U/JPyQ=="
+    },
+    "node_modules/@firebase/app-check/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
+    "node_modules/@firebase/app-compat": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.2.13.tgz",
+      "integrity": "sha512-j6ANZaWjeVy5zg6X7uiqh6lM6o3n3LD1+/SJFNs9V781xyryyZWXe+tmnWNWPkP086QfJoNkWN9pMQRqSG4vMg==",
+      "dependencies": {
+        "@firebase/app": "0.9.13",
+        "@firebase/component": "0.6.4",
+        "@firebase/logger": "0.4.0",
+        "@firebase/util": "1.9.3",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@firebase/app-compat/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
+    "node_modules/@firebase/app-types": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.0.tgz",
+      "integrity": "sha512-AeweANOIo0Mb8GiYm3xhTEBVCmPwTYAu9Hcd2qSkLuga/6+j9b1Jskl5bpiSQWy9eJ/j5pavxj6eYogmnuzm+Q=="
+    },
+    "node_modules/@firebase/app/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
+    "node_modules/@firebase/auth": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-0.23.2.tgz",
+      "integrity": "sha512-dM9iJ0R6tI1JczuGSxXmQbXAgtYie0K4WvKcuyuSTCu9V8eEDiz4tfa1sO3txsfvwg7nOY3AjoCyMYEdqZ8hdg==",
+      "dependencies": {
+        "@firebase/component": "0.6.4",
+        "@firebase/logger": "0.4.0",
+        "@firebase/util": "1.9.3",
+        "node-fetch": "2.6.7",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/auth-compat": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.4.2.tgz",
+      "integrity": "sha512-Q30e77DWXFmXEt5dg5JbqEDpjw9y3/PcP9LslDPR7fARmAOTIY9MM6HXzm9KC+dlrKH/+p6l8g9ifJiam9mc4A==",
+      "dependencies": {
+        "@firebase/auth": "0.23.2",
+        "@firebase/auth-types": "0.12.0",
+        "@firebase/component": "0.6.4",
+        "@firebase/util": "1.9.3",
+        "node-fetch": "2.6.7",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/auth-compat/node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@firebase/auth-compat/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
+    "node_modules/@firebase/auth-interop-types": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.2.1.tgz",
+      "integrity": "sha512-VOaGzKp65MY6P5FI84TfYKBXEPi6LmOCSMMzys6o2BN2LOsqy7pCuZCup7NYnfbk5OkkQKzvIfHOzTm0UDpkyg=="
+    },
+    "node_modules/@firebase/auth-types": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.12.0.tgz",
+      "integrity": "sha512-pPwaZt+SPOshK8xNoiQlK5XIrS97kFYc3Rc7xmy373QsOJ9MmqXxLaYssP5Kcds4wd2qK//amx/c+A8O2fVeZA==",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/auth/node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@firebase/auth/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
+    "node_modules/@firebase/component": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.6.4.tgz",
+      "integrity": "sha512-rLMyrXuO9jcAUCaQXCMjCMUsWrba5fzHlNK24xz5j2W6A/SRmK8mZJ/hn7V0fViLbxC0lPMtrK1eYzk6Fg03jA==",
+      "dependencies": {
+        "@firebase/util": "1.9.3",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@firebase/component/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
+    "node_modules/@firebase/database": {
+      "version": "0.14.4",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.14.4.tgz",
+      "integrity": "sha512-+Ea/IKGwh42jwdjCyzTmeZeLM3oy1h0mFPsTy6OqCWzcu/KFqRAr5Tt1HRCOBlNOdbh84JPZC47WLU18n2VbxQ==",
+      "dependencies": {
+        "@firebase/auth-interop-types": "0.2.1",
+        "@firebase/component": "0.6.4",
+        "@firebase/logger": "0.4.0",
+        "@firebase/util": "1.9.3",
+        "faye-websocket": "0.11.4",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@firebase/database-compat": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-0.3.4.tgz",
+      "integrity": "sha512-kuAW+l+sLMUKBThnvxvUZ+Q1ZrF/vFJ58iUY9kAcbX48U03nVzIF6Tmkf0p3WVQwMqiXguSgtOPIB6ZCeF+5Gg==",
+      "dependencies": {
+        "@firebase/component": "0.6.4",
+        "@firebase/database": "0.14.4",
+        "@firebase/database-types": "0.10.4",
+        "@firebase/logger": "0.4.0",
+        "@firebase/util": "1.9.3",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@firebase/database-compat/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
+    "node_modules/@firebase/database-types": {
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.10.4.tgz",
+      "integrity": "sha512-dPySn0vJ/89ZeBac70T+2tWWPiJXWbmRygYv0smT5TfE3hDrQ09eKMF3Y+vMlTdrMWq7mUdYW5REWPSGH4kAZQ==",
+      "dependencies": {
+        "@firebase/app-types": "0.9.0",
+        "@firebase/util": "1.9.3"
+      }
+    },
+    "node_modules/@firebase/database/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
+    "node_modules/@firebase/firestore": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-3.13.0.tgz",
+      "integrity": "sha512-NwcnU+madJXQ4fbLkGx1bWvL612IJN/qO6bZ6dlPmyf7QRyu5azUosijdAN675r+bOOJxMtP1Bv981bHBXAbUg==",
+      "dependencies": {
+        "@firebase/component": "0.6.4",
+        "@firebase/logger": "0.4.0",
+        "@firebase/util": "1.9.3",
+        "@firebase/webchannel-wrapper": "0.10.1",
+        "@grpc/grpc-js": "~1.7.0",
+        "@grpc/proto-loader": "^0.6.13",
+        "node-fetch": "2.6.7",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10.10.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/firestore-compat": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.3.12.tgz",
+      "integrity": "sha512-mazuNGAx5Kt9Nph0pm6ULJFp/+j7GSsx+Ncw1GrnKl+ft1CQ4q2LcUssXnjqkX2Ry0fNGqUzC1mfIUrk9bYtjQ==",
+      "dependencies": {
+        "@firebase/component": "0.6.4",
+        "@firebase/firestore": "3.13.0",
+        "@firebase/firestore-types": "2.5.1",
+        "@firebase/util": "1.9.3",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/firestore-compat/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
+    "node_modules/@firebase/firestore-types": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-2.5.1.tgz",
+      "integrity": "sha512-xG0CA6EMfYo8YeUxC8FeDzf6W3FX1cLlcAGBYV6Cku12sZRI81oWcu61RSKM66K6kUENP+78Qm8mvroBcm1whw==",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/firestore/node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@firebase/firestore/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
+    "node_modules/@firebase/functions": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.10.0.tgz",
+      "integrity": "sha512-2U+fMNxTYhtwSpkkR6WbBcuNMOVaI7MaH3cZ6UAeNfj7AgEwHwMIFLPpC13YNZhno219F0lfxzTAA0N62ndWzA==",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.0",
+        "@firebase/auth-interop-types": "0.2.1",
+        "@firebase/component": "0.6.4",
+        "@firebase/messaging-interop-types": "0.2.0",
+        "@firebase/util": "1.9.3",
+        "node-fetch": "2.6.7",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/functions-compat": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.3.5.tgz",
+      "integrity": "sha512-uD4jwgwVqdWf6uc3NRKF8cSZ0JwGqSlyhPgackyUPe+GAtnERpS4+Vr66g0b3Gge0ezG4iyHo/EXW/Hjx7QhHw==",
+      "dependencies": {
+        "@firebase/component": "0.6.4",
+        "@firebase/functions": "0.10.0",
+        "@firebase/functions-types": "0.6.0",
+        "@firebase/util": "1.9.3",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/functions-compat/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
+    "node_modules/@firebase/functions-types": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.6.0.tgz",
+      "integrity": "sha512-hfEw5VJtgWXIRf92ImLkgENqpL6IWpYaXVYiRkFY1jJ9+6tIhWM7IzzwbevwIIud/jaxKVdRzD7QBWfPmkwCYw=="
+    },
+    "node_modules/@firebase/functions/node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@firebase/functions/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
+    "node_modules/@firebase/installations": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.6.4.tgz",
+      "integrity": "sha512-u5y88rtsp7NYkCHC3ElbFBrPtieUybZluXyzl7+4BsIz4sqb4vSAuwHEUgCgCeaQhvsnxDEU6icly8U9zsJigA==",
+      "dependencies": {
+        "@firebase/component": "0.6.4",
+        "@firebase/util": "1.9.3",
+        "idb": "7.0.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/installations-compat": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-compat/-/installations-compat-0.2.4.tgz",
+      "integrity": "sha512-LI9dYjp0aT9Njkn9U4JRrDqQ6KXeAmFbRC0E7jI7+hxl5YmRWysq5qgQl22hcWpTk+cm3es66d/apoDU/A9n6Q==",
+      "dependencies": {
+        "@firebase/component": "0.6.4",
+        "@firebase/installations": "0.6.4",
+        "@firebase/installations-types": "0.5.0",
+        "@firebase/util": "1.9.3",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/installations-compat/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
+    "node_modules/@firebase/installations-types": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-types/-/installations-types-0.5.0.tgz",
+      "integrity": "sha512-9DP+RGfzoI2jH7gY4SlzqvZ+hr7gYzPODrbzVD82Y12kScZ6ZpRg/i3j6rleto8vTFC8n6Len4560FnV1w2IRg==",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x"
+      }
+    },
+    "node_modules/@firebase/installations/node_modules/idb": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-7.0.1.tgz",
+      "integrity": "sha512-UUxlE7vGWK5RfB/fDwEGgRf84DY/ieqNha6msMV99UsEMQhJ1RwbCd8AYBj3QMgnE3VZnfQvm4oKVCJTYlqIgg=="
+    },
+    "node_modules/@firebase/installations/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
+    "node_modules/@firebase/logger": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.4.0.tgz",
+      "integrity": "sha512-eRKSeykumZ5+cJPdxxJRgAC3G5NknY2GwEbKfymdnXtnT0Ucm4pspfR6GT4MUQEDuJwRVbVcSx85kgJulMoFFA==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@firebase/logger/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
+    "node_modules/@firebase/messaging": {
+      "version": "0.12.4",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.12.4.tgz",
+      "integrity": "sha512-6JLZct6zUaex4g7HI3QbzeUrg9xcnmDAPTWpkoMpd/GoSVWH98zDoWXMGrcvHeCAIsLpFMe4MPoZkJbrPhaASw==",
+      "dependencies": {
+        "@firebase/component": "0.6.4",
+        "@firebase/installations": "0.6.4",
+        "@firebase/messaging-interop-types": "0.2.0",
+        "@firebase/util": "1.9.3",
+        "idb": "7.0.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/messaging-compat": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-compat/-/messaging-compat-0.2.4.tgz",
+      "integrity": "sha512-lyFjeUhIsPRYDPNIkYX1LcZMpoVbBWXX4rPl7c/rqc7G+EUea7IEtSt4MxTvh6fDfPuzLn7+FZADfscC+tNMfg==",
+      "dependencies": {
+        "@firebase/component": "0.6.4",
+        "@firebase/messaging": "0.12.4",
+        "@firebase/util": "1.9.3",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/messaging-compat/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
+    "node_modules/@firebase/messaging-interop-types": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-interop-types/-/messaging-interop-types-0.2.0.tgz",
+      "integrity": "sha512-ujA8dcRuVeBixGR9CtegfpU4YmZf3Lt7QYkcj693FFannwNuZgfAYaTmbJ40dtjB81SAu6tbFPL9YLNT15KmOQ=="
+    },
+    "node_modules/@firebase/messaging/node_modules/idb": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-7.0.1.tgz",
+      "integrity": "sha512-UUxlE7vGWK5RfB/fDwEGgRf84DY/ieqNha6msMV99UsEMQhJ1RwbCd8AYBj3QMgnE3VZnfQvm4oKVCJTYlqIgg=="
+    },
+    "node_modules/@firebase/messaging/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
+    "node_modules/@firebase/performance": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.6.4.tgz",
+      "integrity": "sha512-HfTn/bd8mfy/61vEqaBelNiNnvAbUtME2S25A67Nb34zVuCSCRIX4SseXY6zBnOFj3oLisaEqhVcJmVPAej67g==",
+      "dependencies": {
+        "@firebase/component": "0.6.4",
+        "@firebase/installations": "0.6.4",
+        "@firebase/logger": "0.4.0",
+        "@firebase/util": "1.9.3",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/performance-compat": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-compat/-/performance-compat-0.2.4.tgz",
+      "integrity": "sha512-nnHUb8uP9G8islzcld/k6Bg5RhX62VpbAb/Anj7IXs/hp32Eb2LqFPZK4sy3pKkBUO5wcrlRWQa6wKOxqlUqsg==",
+      "dependencies": {
+        "@firebase/component": "0.6.4",
+        "@firebase/logger": "0.4.0",
+        "@firebase/performance": "0.6.4",
+        "@firebase/performance-types": "0.2.0",
+        "@firebase/util": "1.9.3",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/performance-compat/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
+    "node_modules/@firebase/performance-types": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-types/-/performance-types-0.2.0.tgz",
+      "integrity": "sha512-kYrbr8e/CYr1KLrLYZZt2noNnf+pRwDq2KK9Au9jHrBMnb0/C9X9yWSXmZkFt4UIdsQknBq8uBB7fsybZdOBTA=="
+    },
+    "node_modules/@firebase/performance/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
+    "node_modules/@firebase/remote-config": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.4.4.tgz",
+      "integrity": "sha512-x1ioTHGX8ZwDSTOVp8PBLv2/wfwKzb4pxi0gFezS5GCJwbLlloUH4YYZHHS83IPxnua8b6l0IXUaWd0RgbWwzQ==",
+      "dependencies": {
+        "@firebase/component": "0.6.4",
+        "@firebase/installations": "0.6.4",
+        "@firebase/logger": "0.4.0",
+        "@firebase/util": "1.9.3",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/remote-config-compat": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-compat/-/remote-config-compat-0.2.4.tgz",
+      "integrity": "sha512-FKiki53jZirrDFkBHglB3C07j5wBpitAaj8kLME6g8Mx+aq7u9P7qfmuSRytiOItADhWUj7O1JIv7n9q87SuwA==",
+      "dependencies": {
+        "@firebase/component": "0.6.4",
+        "@firebase/logger": "0.4.0",
+        "@firebase/remote-config": "0.4.4",
+        "@firebase/remote-config-types": "0.3.0",
+        "@firebase/util": "1.9.3",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/remote-config-compat/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
+    "node_modules/@firebase/remote-config-types": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.3.0.tgz",
+      "integrity": "sha512-RtEH4vdcbXZuZWRZbIRmQVBNsE7VDQpet2qFvq6vwKLBIQRQR5Kh58M4ok3A3US8Sr3rubYnaGqZSurCwI8uMA=="
+    },
+    "node_modules/@firebase/remote-config/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
+    "node_modules/@firebase/storage": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.11.2.tgz",
+      "integrity": "sha512-CtvoFaBI4hGXlXbaCHf8humajkbXhs39Nbh6MbNxtwJiCqxPy9iH3D3CCfXAvP0QvAAwmJUTK3+z9a++Kc4nkA==",
+      "dependencies": {
+        "@firebase/component": "0.6.4",
+        "@firebase/util": "1.9.3",
+        "node-fetch": "2.6.7",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/storage-compat": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.3.2.tgz",
+      "integrity": "sha512-wvsXlLa9DVOMQJckbDNhXKKxRNNewyUhhbXev3t8kSgoCotd1v3MmqhKKz93ePhDnhHnDs7bYHy+Qa8dRY6BXw==",
+      "dependencies": {
+        "@firebase/component": "0.6.4",
+        "@firebase/storage": "0.11.2",
+        "@firebase/storage-types": "0.8.0",
+        "@firebase/util": "1.9.3",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/storage-compat/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
+    "node_modules/@firebase/storage-types": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.8.0.tgz",
+      "integrity": "sha512-isRHcGrTs9kITJC0AVehHfpraWFui39MPaU7Eo8QfWlqW7YPymBmRgjDrlOgFdURh6Cdeg07zmkLP5tzTKRSpg==",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/storage/node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@firebase/storage/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
+    "node_modules/@firebase/util": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.9.3.tgz",
+      "integrity": "sha512-DY02CRhOZwpzO36fHpuVysz6JZrscPiBXD0fXp6qSrL9oNOx5KWICKdR95C0lSITzxp0TZosVyHqzatE8JbcjA==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@firebase/util/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
+    "node_modules/@firebase/webchannel-wrapper": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.10.1.tgz",
+      "integrity": "sha512-Dq5rYfEpdeel0bLVN+nfD1VWmzCkK+pJbSjIawGE+RY4+NIJqhbUDDQjvV0NUK84fMfwxvtFoCtEe70HfZjFcw=="
+    },
     "node_modules/@floating-ui/core": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.3.0.tgz",
@@ -2772,6 +3496,119 @@
       "peerDependencies": {
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.7.3.tgz",
+      "integrity": "sha512-H9l79u4kJ2PVSxUNA08HMYAnUBLj9v6KjYQ7SQ71hOZcEXhShE/y5iQCesP8+6/Ik/7i2O0a10bPquIcYfufog==",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.7.0",
+        "@types/node": ">=12.12.47"
+      },
+      "engines": {
+        "node": "^8.13.0 || >=10.10.0"
+      }
+    },
+    "node_modules/@grpc/grpc-js/node_modules/@grpc/proto-loader": {
+      "version": "0.7.10",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.10.tgz",
+      "integrity": "sha512-CAqDfoaQ8ykFd9zqBDn4k6iWT9loLAlc2ETmDFS9JCD70gDcnA4L3AFEo2iV7KyAtAAHFW9ftq1Fz+Vsgq80RQ==",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.2.4",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@grpc/grpc-js/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@grpc/grpc-js/node_modules/long": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
+    },
+    "node_modules/@grpc/grpc-js/node_modules/protobufjs": {
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.5.tgz",
+      "integrity": "sha512-gGXRSXvxQ7UiPgfw8gevrfRWcTlSbOFg+p/N+JVJEK5VhueL2miT6qTymqAmjr1Q5WbOCyJbyrk6JfWKwlFn6A==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@grpc/grpc-js/node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@grpc/grpc-js/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.6.13",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.6.13.tgz",
+      "integrity": "sha512-FjxPYDRTn6Ec3V0arm1FtSpmP6V50wuph2yILpyvTKzjc76oDdoihXqM1DzOW5ubvCC8GivfCnNtfaRE8myJ7g==",
+      "dependencies": {
+        "@types/long": "^4.0.1",
+        "lodash.camelcase": "^4.3.0",
+        "long": "^4.0.0",
+        "protobufjs": "^6.11.3",
+        "yargs": "^16.2.0"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -3557,6 +4394,14 @@
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
       "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A=="
     },
+    "node_modules/@mongodb-js/saslprep": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.0.tgz",
+      "integrity": "sha512-Xfijy7HvfzzqiOAhAepF4SGN5e9leLkMvg/OPOF97XemjfVCYN/oWa75wnkc6mltMSTwY+XlbhWgUOJmkFspSw==",
+      "dependencies": {
+        "sparse-bitfield": "^3.0.3"
+      }
+    },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
       "version": "5.1.1-v1",
       "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz",
@@ -3736,6 +4581,60 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "node_modules/@radix-ui/number": {
       "version": "1.0.1",
@@ -4628,6 +5527,11 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
+      "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg=="
+    },
     "node_modules/@surma/rollup-plugin-off-main-thread": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/@surma/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-2.2.3.tgz",
@@ -5180,6 +6084,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@types/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-fKXTsQvII/8K7xSxQF2OEuN6Pt4/PDasws60s/qeqoIOaBX7Aoevy5CmaQ4fANbvOo04MN3kx3xUIc6ZNXsmaQ=="
+    },
+    "node_modules/@types/common-tags": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@types/common-tags/-/common-tags-1.8.1.tgz",
+      "integrity": "sha512-20R/mDpKSPWdJs5TOpz3e7zqbeCNuMCPhV7Yndk9KU2Rbij2r5W4RzwDPkzC+2lzUqXYu9rFzTktCBnDjHuNQg=="
+    },
     "node_modules/@types/connect": {
       "version": "3.4.35",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
@@ -5194,6 +6108,14 @@
       "integrity": "sha512-4x5FkPpLipqwthjPsF7ZRbOv3uoLUFkTA9G9v583qi4pACvq0uTELrB8OLUzPWUI4IJIyvM85vzkV1nyiI2Lig==",
       "dependencies": {
         "@types/express-serve-static-core": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cors": {
+      "version": "2.8.14",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.14.tgz",
+      "integrity": "sha512-RXHUvNWYICtbP6s18PnOCaqToK8y14DnLd75c6HfyKf228dxy7pHNOQkxPtvXKp/hINFMDjbYzsj63nnpPMSRQ==",
+      "dependencies": {
         "@types/node": "*"
       }
     },
@@ -5221,9 +6143,9 @@
       "integrity": "sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA=="
     },
     "node_modules/@types/express": {
-      "version": "4.17.17",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.17.tgz",
-      "integrity": "sha512-Q4FmmuLGBG58btUnfS1c1r/NQdlp3DMfGDGig8WhfpA2YRUtEkxAjkZb0yvplJGYdF1fsQ81iMDcH24sSCNC/Q==",
+      "version": "4.17.18",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.18.tgz",
+      "integrity": "sha512-Sxv8BSLLgsBYmcnGdGjjEjqET2U+AKAdCRODmMiq02FgjwuV75Ut85DRpvFjyw/Mk0vgUOliGRU0UUmuuZHByQ==",
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.33",
@@ -5313,6 +6235,16 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="
+    },
+    "node_modules/@types/lokijs": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/@types/lokijs/-/lokijs-1.5.10.tgz",
+      "integrity": "sha512-Q/F6OUCZPHWY4hzEowhCswi9Tafc/E7DCUyyWIOH3+hM3K96Mkj2U3byfzs7Yd542I8gT/8oUALnoddqdA20xg=="
+    },
+    "node_modules/@types/long": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
+      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
     },
     "node_modules/@types/mime": {
       "version": "1.3.2",
@@ -5455,6 +6387,14 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/simple-peer": {
+      "version": "9.11.5",
+      "resolved": "https://registry.npmjs.org/@types/simple-peer/-/simple-peer-9.11.5.tgz",
+      "integrity": "sha512-haXgWcAa3Y3Sn+T8lzkE4ErQUpYzhW6Cz2lh00RhQTyWt+xZ3s87wJPztUxlqSdFRqGhe2MQIBd0XsyHP3No4w==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/sockjs": {
       "version": "0.3.33",
       "resolved": "https://registry.npmjs.org/@types/sockjs/-/sockjs-0.3.33.tgz",
@@ -5472,6 +6412,20 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.3.tgz",
       "integrity": "sha512-NfQ4gyz38SL8sDNrSixxU2Os1a5xcdFxipAFxYEuLUlvU2uDwS4NUpsImcf1//SlWItCVMMLiylsxbmNMToV/g=="
+    },
+    "node_modules/@types/webidl-conversions": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.1.tgz",
+      "integrity": "sha512-8hKOnOan+Uu+NgMaCouhg3cT9x5fFZ92Jwf+uDLXLu/MFRbXxlWwGeQY7KVHkeSft6RvY+tdxklUBuyY9eIEKg=="
+    },
+    "node_modules/@types/whatwg-url": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
+      "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/webidl-conversions": "*"
+      }
     },
     "node_modules/@types/ws": {
       "version": "8.5.5",
@@ -6257,6 +7211,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/array-push-at-sort-position": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/array-push-at-sort-position/-/array-push-at-sort-position-3.0.0.tgz",
+      "integrity": "sha512-U0ehr2otaSYeaDOSHY9Hu/E0k6GL4NrjP4qUyoUKbNTNOer2RCvdiaVkd2Dqg/ltGTrEng5o36so3qBaIWJPvg=="
+    },
     "node_modules/array-union": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
@@ -6328,6 +7287,11 @@
         "es-shim-unscopables": "^1.0.0",
         "get-intrinsic": "^1.1.3"
       }
+    },
+    "node_modules/as-typed": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/as-typed/-/as-typed-1.3.2.tgz",
+      "integrity": "sha512-94ezeKlKB97OJUyMaU7dQUAB+Cmjlgr4T9/cxCoKaLM4F2HAmuIHm3Q5ClGCsX5PvRwCQehCzAa/6foRFXRbqA=="
     },
     "node_modules/asap": {
       "version": "2.0.6",
@@ -6830,6 +7794,11 @@
         "node": "*"
       }
     },
+    "node_modules/binary-decision-diagram": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/binary-decision-diagram/-/binary-decision-diagram-2.0.1.tgz",
+      "integrity": "sha512-ijgglbVBVOW+JtzBQSSjAHccFYx3m+6YEMRnLkfppMgkwyuJczx42eNhop95bRQmsuVHxpza1/E7KxZEvg9gNA=="
+    },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -6946,6 +7915,36 @@
         "node": ">=8"
       }
     },
+    "node_modules/broadcast-channel": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/broadcast-channel/-/broadcast-channel-5.3.0.tgz",
+      "integrity": "sha512-0PmDYc/iUGZ4QbnCnV7u+WleygiS1bZ4oV6t4rANXYtSgEFtGhB5jimJPLOVpPtce61FVxrH8CYylfO5g7OLKw==",
+      "dependencies": {
+        "@babel/runtime": "7.22.10",
+        "oblivious-set": "1.1.1",
+        "p-queue": "6.6.2",
+        "unload": "2.4.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/pubkey"
+      }
+    },
+    "node_modules/broadcast-channel/node_modules/@babel/runtime": {
+      "version": "7.22.10",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.10.tgz",
+      "integrity": "sha512-21t/fkKLMZI4pqP2wlmsQAWnYW1PDyKyyUV4vCi+B25ydmdaYTKXPwCj0BzSUnZf4seIiYvSA3jcZ3gdsMFkLQ==",
+      "dependencies": {
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/broadcast-channel/node_modules/regenerator-runtime": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
+      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
+    },
     "node_modules/browser-process-hrtime": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
@@ -6988,6 +7987,14 @@
       "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
       "dependencies": {
         "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/bson": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.1.0.tgz",
+      "integrity": "sha512-yiQ3KxvpVoRpx1oD1uPz4Jit9tAVTJgjdmjDKtUErkOoL9VNoF8Dd58qtAOL5E40exx2jvAT9sqdRSK/r+SHlA==",
+      "engines": {
+        "node": ">=16.20.1"
       }
     },
     "node_modules/buffer": {
@@ -7300,6 +8307,14 @@
         "wrap-ansi": "^7.0.0"
       }
     },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/clsx": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
@@ -7601,6 +8616,11 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/crypto-js": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
+      "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
     },
     "node_modules/crypto-random-string": {
       "version": "2.0.0",
@@ -8022,6 +9042,22 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
       "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
     },
+    "node_modules/custom-idle-queue": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/custom-idle-queue/-/custom-idle-queue-3.0.1.tgz",
+      "integrity": "sha512-n/c555GViLgmqj1364lrnlxCQtNXGBqZs/W8j/SXnLyZWXHtMq1xjQ2ba8Va8AZu6VZF+1AEnF+gcKfoHVAVNg==",
+      "dependencies": {
+        "@babel/runtime": "7.9.6"
+      }
+    },
+    "node_modules/custom-idle-queue/node_modules/@babel/runtime": {
+      "version": "7.9.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.6.tgz",
+      "integrity": "sha512-64AF1xY3OAkFHqOb9s4jpgk1Mm5vDZ4L3acHvAml+53nO1XbXLuDodsVpO4OIUsmemlUHMxNdYMNJmsvOwLrvQ==",
+      "dependencies": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
     "node_modules/cva": {
       "name": "class-variance-authority",
       "version": "0.6.0",
@@ -8291,6 +9327,11 @@
         "node": ">=6"
       }
     },
+    "node_modules/defekt": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/defekt/-/defekt-9.3.0.tgz",
+      "integrity": "sha512-AWfM0vhFmESRZawEJfLhRJMsAR5IOhwyxGxIDOh9RXGKcdV65cWtkFB31MNjUfFvAlfbk3c2ooX0rr1pWIXshw=="
+    },
     "node_modules/define-lazy-prop": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
@@ -8394,6 +9435,14 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+    },
+    "node_modules/dexie": {
+      "version": "4.0.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/dexie/-/dexie-4.0.0-alpha.4.tgz",
+      "integrity": "sha512-xYABeT5ctG7WAJtyr/6gKhWXD6NY8ydZieQlvLQkFV6KXY33I+ShE39pToGzQw+3/xs760rW+opxhoVZ/yzVxQ==",
+      "engines": {
+        "node": ">=6.0"
+      }
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -8633,6 +9682,46 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/engine.io-client": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.5.2.tgz",
+      "integrity": "sha512-CQZqbrpEYnrpGqC07a9dJDz4gePZUgTPMU3NKJPSeQOyw27Tst4Pl3FemKoFGAlHzgZmKjoRmiJvbWfhCXUlIg==",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.11.0",
+        "xmlhttprequest-ssl": "~2.0.0"
+      }
+    },
+    "node_modules/engine.io-client/node_modules/ws": {
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.1.tgz",
+      "integrity": "sha512-9JktcM3u18nU9N2Lz3bWeBgxVgOKpw7yhRaoxQA3FUDZzzw+9WlA6p4G4u0RixNkg14fH7EfEc/RhpurtiROTQ==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/enhanced-resolve": {
       "version": "5.15.0",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.15.0.tgz",
@@ -8656,6 +9745,11 @@
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
+    },
+    "node_modules/err-code": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-3.0.1.tgz",
+      "integrity": "sha512-GiaH0KJUewYok+eeY05IIgjtAe4Yltygk9Wqp1V5yVWLdhf0hYZchRjNIT9bb0mSwRcIusT3cx7PJUf3zEIfUA=="
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
@@ -9698,6 +10792,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/event-reduce-js": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/event-reduce-js/-/event-reduce-js-3.1.2.tgz",
+      "integrity": "sha512-DATsZc4EpIRlcTgmyHjpn6l+U6GL/9FPsecguhNxE82usQmoZ40Mo8YxzoWCFIeXRBO9xGO3M4lknq0cXTHWZg==",
+      "dependencies": {
+        "array-push-at-sort-position": "3.0.0",
+        "binary-decision-diagram": "2.0.1"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
@@ -10031,6 +11134,39 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/firebase": {
+      "version": "9.23.0",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-9.23.0.tgz",
+      "integrity": "sha512-/4lUVY0lUvBDIaeY1q6dUYhS8Sd18Qb9CgWkPZICUo9IXpJNCEagfNZXBBFCkMTTN5L5gx2Hjr27y21a9NzUcA==",
+      "dependencies": {
+        "@firebase/analytics": "0.10.0",
+        "@firebase/analytics-compat": "0.2.6",
+        "@firebase/app": "0.9.13",
+        "@firebase/app-check": "0.8.0",
+        "@firebase/app-check-compat": "0.3.7",
+        "@firebase/app-compat": "0.2.13",
+        "@firebase/app-types": "0.9.0",
+        "@firebase/auth": "0.23.2",
+        "@firebase/auth-compat": "0.4.2",
+        "@firebase/database": "0.14.4",
+        "@firebase/database-compat": "0.3.4",
+        "@firebase/firestore": "3.13.0",
+        "@firebase/firestore-compat": "0.3.12",
+        "@firebase/functions": "0.10.0",
+        "@firebase/functions-compat": "0.3.5",
+        "@firebase/installations": "0.6.4",
+        "@firebase/installations-compat": "0.2.4",
+        "@firebase/messaging": "0.12.4",
+        "@firebase/messaging-compat": "0.2.4",
+        "@firebase/performance": "0.6.4",
+        "@firebase/performance-compat": "0.2.4",
+        "@firebase/remote-config": "0.4.4",
+        "@firebase/remote-config-compat": "0.2.4",
+        "@firebase/storage": "0.11.2",
+        "@firebase/storage-compat": "0.3.2",
+        "@firebase/util": "1.9.3"
+      }
+    },
     "node_modules/flat-cache": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
@@ -10338,6 +11474,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/generate-function": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "dependencies": {
+        "is-property": "^1.0.2"
+      }
+    },
+    "node_modules/generate-object-property": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "integrity": "sha512-TuOwZWgJ2VAMEGJvAyPWvpqxSANF0LDpmyHauMjFYzaACvn+QTT/AZomvPCzVBV7yDN3OmwHQ5OvHaeLKre3JQ==",
+      "dependencies": {
+        "is-property": "^1.0.0"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -10346,6 +11498,11 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/get-browser-rtc": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/get-browser-rtc/-/get-browser-rtc-1.1.0.tgz",
+      "integrity": "sha512-MghbMJ61EJrRsDe7w1Bvqt3ZsBuqhce5nrn/XAwgwOXhcsz53/ltdxOse1h/8eKXj5slzxdsz56g5rzOFSGwfQ=="
+    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -10353,6 +11510,22 @@
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
+    },
+    "node_modules/get-graphql-from-jsonschema": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/get-graphql-from-jsonschema/-/get-graphql-from-jsonschema-8.1.0.tgz",
+      "integrity": "sha512-MhvxGPBjJm1ls6XmvcmgJG7ApqxkFEs5T8uDzytlpbMBBwMMnoF/rMUWzPxM6YvejyLhCB3axD4Dwci3G5F4UA==",
+      "dependencies": {
+        "@types/common-tags": "1.8.1",
+        "@types/json-schema": "7.0.11",
+        "common-tags": "1.8.2",
+        "defekt": "9.3.0"
+      }
+    },
+    "node_modules/get-graphql-from-jsonschema/node_modules/@types/json-schema": {
+      "version": "7.0.11",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
+      "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ=="
     },
     "node_modules/get-intrinsic": {
       "version": "1.2.1",
@@ -10580,6 +11753,25 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag=="
+    },
+    "node_modules/graphql": {
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.8.0.tgz",
+      "integrity": "sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/graphql-ws": {
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.14.0.tgz",
+      "integrity": "sha512-itrUTQZP/TgswR4GSSYuwWUzrE/w5GhbwM2GX3ic2U7aw33jgEsayfIlvaj7/GcIvZgNMzsPTrE5hqPuFUiE5g==",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "graphql": ">=0.11 <=16"
+      }
     },
     "node_modules/gzip-size": {
       "version": "6.0.0",
@@ -11330,6 +12522,20 @@
         "node": ">=6"
       }
     },
+    "node_modules/is-generator-function": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
+      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -11371,6 +12577,23 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
       "integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g=="
+    },
+    "node_modules/is-my-ip-valid": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.1.tgz",
+      "integrity": "sha512-jxc8cBcOWbNK2i2aTkCZP6i7wkHF1bqKFrwEHuN5Jtg5BSaZHUZQ/JTOJwoV41YvHnOaRyWWh72T/KvfNz9DJg=="
+    },
+    "node_modules/is-my-json-valid": {
+      "version": "2.20.6",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.20.6.tgz",
+      "integrity": "sha512-1JQwulVNjx8UqkPE/bqDaxtH4PXCe/2VRh/y3p99heOV87HG4Id5/VfDswd+YiAfHcRTfDlWgISycnHuhZq1aw==",
+      "dependencies": {
+        "generate-function": "^2.0.0",
+        "generate-object-property": "^1.1.0",
+        "is-my-ip-valid": "^1.0.0",
+        "jsonpointer": "^5.0.0",
+        "xtend": "^4.0.0"
+      }
     },
     "node_modules/is-negative-zero": {
       "version": "2.0.2",
@@ -11436,6 +12659,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="
+    },
+    "node_modules/is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g=="
     },
     "node_modules/is-regex": {
       "version": "1.1.4",
@@ -11615,6 +12843,14 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+    },
+    "node_modules/isomorphic-ws": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz",
+      "integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==",
+      "peerDependencies": {
+        "ws": "*"
+      }
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.0",
@@ -13859,6 +15095,11 @@
         "jiti": "bin/jiti.js"
       }
     },
+    "node_modules/js-base64": {
+      "version": "3.7.5",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.5.tgz",
+      "integrity": "sha512-3MEt5DTINKqfScXKfJFrRbxkrnk2AxPWGBL/ycjz4dK8iqiSJ06UxD8jh8xuh6p10TX4t2+7FsBYVxxQbMg+qA=="
+    },
     "node_modules/js-sha256": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
@@ -14026,6 +15267,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/jsonschema-key-compression": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/jsonschema-key-compression/-/jsonschema-key-compression-1.6.1.tgz",
+      "integrity": "sha512-7SIbS09K7J40sd/hKCAOLQ1ss45aQ76pz99K1esBlgH/CkdCbetTEx6v+gPeCIXwnT1VHU5JKGjNbJO7ktZNFQ=="
+    },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.3.tgz",
@@ -14157,6 +15403,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
+    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -14166,6 +15417,11 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
@@ -14186,6 +15442,16 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ=="
+    },
+    "node_modules/lokijs": {
+      "version": "1.5.12",
+      "resolved": "https://registry.npmjs.org/lokijs/-/lokijs-1.5.12.tgz",
+      "integrity": "sha512-Q5ALD6JiS6xAUWCwX3taQmgwxyveCtIIuL08+ml0nHwT3k0S/GIFJN+Hd38b1qYIMaE5X++iqsqWVksz7SYW+Q=="
+    },
+    "node_modules/long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -14286,6 +15552,11 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/memory-pager": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg=="
+    },
     "node_modules/merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
@@ -14365,6 +15636,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/mingo": {
+      "version": "6.4.4",
+      "resolved": "https://registry.npmjs.org/mingo/-/mingo-6.4.4.tgz",
+      "integrity": "sha512-GtgwqyBVLxKf8tSvN26TjbK+XAUW5HlWR3D7qBsBh9urQyZznqG2BOx90t3MXklpSxawjvaANiWFUCIxd9xa7w=="
     },
     "node_modules/mini-css-extract-plugin": {
       "version": "2.7.6",
@@ -14468,12 +15744,122 @@
         "mkdirp": "bin/cmd.js"
       }
     },
+    "node_modules/modifyjs": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/modifyjs/-/modifyjs-0.3.1.tgz",
+      "integrity": "sha512-ipVEwcDcvOSX/pgYeftlTf8/MYNMlUM6tjzsPxGv1fJZvjXEISssgWLfQx8/F+ZRFHQrfdvPKNHGQQpCFU4mmg==",
+      "dependencies": {
+        "clone": "^2.1.1",
+        "deep-equal": "^1.0.1"
+      }
+    },
+    "node_modules/modifyjs/node_modules/deep-equal": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
+      "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
+      "dependencies": {
+        "is-arguments": "^1.0.4",
+        "is-date-object": "^1.0.1",
+        "is-regex": "^1.0.4",
+        "object-is": "^1.0.1",
+        "object-keys": "^1.1.1",
+        "regexp.prototype.flags": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/moment": {
       "version": "2.29.4",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
       "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/mongodb": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.1.0.tgz",
+      "integrity": "sha512-AvzNY0zMkpothZ5mJAaIo2bGDjlJQqqAbn9fvtVgwIIUPEfdrqGxqNjjbuKyrgQxg2EvCmfWdjq+4uj96c0YPw==",
+      "dependencies": {
+        "@mongodb-js/saslprep": "^1.1.0",
+        "bson": "^6.1.0",
+        "mongodb-connection-string-url": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.188.0",
+        "@mongodb-js/zstd": "^1.1.0",
+        "gcp-metadata": "^5.2.0",
+        "kerberos": "^2.0.1",
+        "mongodb-client-encryption": ">=6.0.0 <7",
+        "snappy": "^7.2.2",
+        "socks": "^2.7.1"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "@mongodb-js/zstd": {
+          "optional": true
+        },
+        "gcp-metadata": {
+          "optional": true
+        },
+        "kerberos": {
+          "optional": true
+        },
+        "mongodb-client-encryption": {
+          "optional": true
+        },
+        "snappy": {
+          "optional": true
+        },
+        "socks": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mongodb-connection-string-url": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
+      "integrity": "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==",
+      "dependencies": {
+        "@types/whatwg-url": "^8.2.1",
+        "whatwg-url": "^11.0.0"
+      }
+    },
+    "node_modules/mongodb-connection-string-url/node_modules/tr46": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "dependencies": {
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/mongodb-connection-string-url/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/mongodb-connection-string-url/node_modules/whatwg-url": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+      "dependencies": {
+        "tr46": "^3.0.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ms": {
@@ -14520,6 +15906,17 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/nats": {
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/nats/-/nats-2.17.0.tgz",
+      "integrity": "sha512-749TtweWL6bc9R9yNra4a+tuk8J0bqurxcPV/9R2D+WPTplY4PPde/LPSXspqR/eCCTxiM80/AjVlfboEafRxA==",
+      "dependencies": {
+        "nkeys.js": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -14542,6 +15939,17 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
+    },
+    "node_modules/nkeys.js": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nkeys.js/-/nkeys.js-1.0.5.tgz",
+      "integrity": "sha512-u25YnRPHiGVsNzwyHnn+PT90sgAhnS8jUJ1nxmkHMFYCJ6+Ic0lv291w7uhRBpJVJ3PH2GWbYqA151lGCRrB5g==",
+      "dependencies": {
+        "tweetnacl": "1.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/no-case": {
       "version": "3.0.4",
@@ -14814,10 +16222,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/oblivious-set": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/oblivious-set/-/oblivious-set-1.1.1.tgz",
+      "integrity": "sha512-Oh+8fK09mgGmAshFdH6hSVco6KZmd1tTwNFWj35OvzdmJTMZtAkbn05zar2iG3v6sDs1JLEtOiBGNb6BHwkb2w=="
+    },
     "node_modules/obuf": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
       "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg=="
+    },
+    "node_modules/ohash": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/ohash/-/ohash-1.1.3.tgz",
+      "integrity": "sha512-zuHHiGTYTA1sYJ/wZN+t5HKZaH23i4yI1HMwbuXm24Nid7Dv0KcuRlKoNKS9UNfAVSBlnGLcuQrnOKWOZoEGaw=="
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
@@ -14895,6 +16313,14 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -14923,6 +16349,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-queue": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+      "dependencies": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/p-retry": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
@@ -14935,6 +16376,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "dependencies": {
+        "p-finally": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
@@ -14942,6 +16394,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
     },
     "node_modules/param-case": {
       "version": "3.0.4",
@@ -16523,6 +17980,31 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
+    "node_modules/protobufjs": {
+      "version": "6.11.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.4.tgz",
+      "integrity": "sha512-5kQWPaJHi1WoCpjTGszzQ32PG2F4+wRY6BmAT4Vfw56Q2FZ4YZzK20xUYQH4YkfehY1e6QSICrJquM6xXZNcrw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/long": "^4.0.1",
+        "@types/node": ">=13.7.0",
+        "long": "^4.0.0"
+      },
+      "bin": {
+        "pbjs": "bin/pbjs",
+        "pbts": "bin/pbts"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -17204,6 +18686,11 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/reconnecting-websocket": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/reconnecting-websocket/-/reconnecting-websocket-4.4.0.tgz",
+      "integrity": "sha512-D2E33ceRPga0NvTDhJmphEgJ7FUYF0v4lr1ki0csq06OdlxKfugGzN0dSkxM/NfqCxYELK4KcaTOUOjTV6Dcng=="
+    },
     "node_modules/recrawl-sync": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/recrawl-sync/-/recrawl-sync-2.2.3.tgz",
@@ -17669,6 +19156,110 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/rxdb": {
+      "version": "14.17.1",
+      "resolved": "https://registry.npmjs.org/rxdb/-/rxdb-14.17.1.tgz",
+      "integrity": "sha512-uJEkJn2RS3OTXdVKAKsqiVmnnObugqoZOqzW/zN2qzVqqMkuvhypuFgOWCfGuYijY2MN7vIB+1BHdUJ637/VrA==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@babel/runtime": "7.22.15",
+        "@types/clone": "2.1.2",
+        "@types/cors": "2.8.14",
+        "@types/express": "4.17.18",
+        "@types/lokijs": "1.5.10",
+        "@types/simple-peer": "9.11.5",
+        "@types/ws": "8.5.5",
+        "ajv": "8.12.0",
+        "array-push-at-sort-position": "3.0.0",
+        "as-typed": "1.3.2",
+        "broadcast-channel": "5.3.0",
+        "crypto-js": "4.1.1",
+        "custom-idle-queue": "3.0.1",
+        "dexie": "4.0.0-alpha.4",
+        "event-reduce-js": "3.1.2",
+        "firebase": "9.23.0",
+        "get-graphql-from-jsonschema": "8.1.0",
+        "graphql": "15.8.0",
+        "graphql-ws": "5.14.0",
+        "is-my-json-valid": "2.20.6",
+        "isomorphic-ws": "5.0.0",
+        "js-base64": "3.7.5",
+        "jsonschema-key-compression": "1.6.1",
+        "lokijs": "1.5.12",
+        "mingo": "6.4.4",
+        "modifyjs": "0.3.1",
+        "mongodb": "6.1.0",
+        "nats": "2.17.0",
+        "oblivious-set": "1.1.1",
+        "ohash": "1.1.3",
+        "pako": "2.1.0",
+        "reconnecting-websocket": "4.4.0",
+        "simple-peer": "9.11.1",
+        "socket.io-client": "4.7.2",
+        "unload": "2.4.1",
+        "util": "0.12.5",
+        "ws": "8.14.2",
+        "z-schema": "6.0.1"
+      },
+      "peerDependencies": {
+        "rxjs": "^7.8.0"
+      }
+    },
+    "node_modules/rxdb/node_modules/ajv": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/rxdb/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "node_modules/rxdb/node_modules/ws": {
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
+      "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/rxjs/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "peer": true
+    },
     "node_modules/safe-array-concat": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.0.0.tgz",
@@ -18068,6 +19659,34 @@
       "resolved": "https://registry.npmjs.org/simple-cbor/-/simple-cbor-0.4.1.tgz",
       "integrity": "sha512-rijcxtwx2b4Bje3sqeIqw5EeW7UlOIC4YfOdwqIKacpvRQ/D78bWg/4/0m5e0U91oKvlGh7LlJuZCu07ISCC7w=="
     },
+    "node_modules/simple-peer": {
+      "version": "9.11.1",
+      "resolved": "https://registry.npmjs.org/simple-peer/-/simple-peer-9.11.1.tgz",
+      "integrity": "sha512-D1SaWpOW8afq1CZGWB8xTfrT3FekjQmPValrqncJMX7QFl8YwhrPTZvMCANLtgBwwdS+7zURyqxDDEmY558tTw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "buffer": "^6.0.3",
+        "debug": "^4.3.2",
+        "err-code": "^3.0.1",
+        "get-browser-rtc": "^1.1.0",
+        "queue-microtask": "^1.2.3",
+        "randombytes": "^2.1.0",
+        "readable-stream": "^3.6.0"
+      }
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -18079,6 +19698,32 @@
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/socket.io-client": {
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.7.2.tgz",
+      "integrity": "sha512-vtA0uD4ibrYD793SOIAwlo8cj6haOeMHrGvwPxJsxH7CeIksqJ+3Zc06RvWTIFgiSqx4A3sOnTXpfAEE2Zyz6w==",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.2",
+        "engine.io-client": "~6.5.2",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
+      "integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/sockjs": {
@@ -18146,6 +19791,14 @@
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
       "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
       "deprecated": "Please use @jridgewell/sourcemap-codec instead"
+    },
+    "node_modules/sparse-bitfield": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
+      "dependencies": {
+        "memory-pager": "^1.0.2"
+      }
     },
     "node_modules/spdy": {
       "version": "4.0.2",
@@ -19311,6 +20964,14 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/unload": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/unload/-/unload-2.4.1.tgz",
+      "integrity": "sha512-IViSAm8Z3sRBYA+9wc0fLQmU9Nrxb16rcDmIiR6Y9LJSZzI7QY5QsDhqPpKOjAn0O9/kfK1TfNEMMAGPTIraPw==",
+      "funding": {
+        "url": "https://github.com/sponsors/pubkey"
+      }
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -19439,6 +21100,18 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
       "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
     },
+    "node_modules/util": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "which-typed-array": "^1.1.2"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -19503,6 +21176,14 @@
       "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/validator": {
+      "version": "13.11.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.11.0.tgz",
+      "integrity": "sha512-Ii+sehpSfZy+At5nPdnyMhx78fEoPDkR2XW/zimHEL3MyGJQOCQ7WeP20jPYRz7ZCpcKLB21NxuXHF3bxjStBQ==",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/value-equal": {
@@ -20688,6 +22369,22 @@
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
     },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.0.0.tgz",
+      "integrity": "sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -20751,6 +22448,34 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/z-schema": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-6.0.1.tgz",
+      "integrity": "sha512-9L2G/s1hJ0bWUfhPRIpY4TZIlBEesnE8NceGrpGIuCmEDTsN98rmGD5tKYgXHlQ/ypEfmZiTP3gnAGW/6gFyhQ==",
+      "dependencies": {
+        "lodash.get": "^4.4.2",
+        "lodash.isequal": "^4.5.0",
+        "validator": "^13.7.0"
+      },
+      "bin": {
+        "z-schema": "bin/z-schema"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "optionalDependencies": {
+        "commander": "^10.0.0"
+      }
+    },
+    "node_modules/z-schema/node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "react-redux": "^7.2.5",
     "react-router-dom": "^5.3.4",
     "react-scripts": "^5.0.1",
+    "rxdb": "^14.17.1",
     "sass": "^1.39.0",
     "twin.macro": "^3.1.0",
     "typescript": "^5.0.2",


### PR DESCRIPTION
This PR adds ability to replace local storage with RXDB as in-browser storage of tokens and contacts; adds RXDB replica canister which allows to sync RXDB data changes on the fly. Old implementation with local storage is still supported by changing environment variable `VITE_DB_STORAGE`